### PR TITLE
Fix parsing error in inner object, offers

### DIFF
--- a/parsers/src/offer_response.rs
+++ b/parsers/src/offer_response.rs
@@ -171,7 +171,7 @@ struct Offers {
     #[serde(default)]
     unknown23: Option<String>,
     #[serde(default)]
-    unknown24: bool,
+    unknown24: Option<bool>,
     #[serde(default)]
     unknown25: Option<GreenFareInfo>,
     #[serde(default)]


### PR DESCRIPTION
This pull request fixes a parsing error in the inner object, offers, by adding an optional value that was missing. The error was causing the processing of the inner object to fail. This fix ensures that the unknown24 field is now of type Option<bool> instead of bool. This resolves issue #19.