### PR TITLE
Refactor code: Add default serde attributes

### DIFF
--- a/parsers/src/common.rs
+++ b/parsers/src/common.rs
@@ -219,7 +219,6 @@ impl From<i32> for TravelClass {
             _ => panic!("Travel class can only be 1,2,3,4, found {}", value),
         }
     }
-
 }
 
 /// Stop options. It can be all, no stop, one or less, two or less.
@@ -251,7 +250,6 @@ impl From<i32> for StopOptions {
             _ => panic!("Stop options can only be 0,1,2,3, found {}", value),
         }
     }
-
 }
 
 /// Travelers. It contains the number of adults, children, infants on lap and infants in seat.

--- a/parsers/src/flight_response.rs
+++ b/parsers/src/flight_response.rs
@@ -56,8 +56,10 @@ impl SerializeToWeb for Date {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(default)]
 pub struct Hour {
     //hour = None = hour after midnight
+    #[serde(default)]
     hour: Option<i32>,
     #[serde(default)]
     minute: i32,
@@ -390,7 +392,9 @@ struct CheaperTravelDifferentDatesContainer {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct CheaperTravelDifferentPlaces {
+    #[serde(default)]
     dates: Option<Vec<CheaperTravelDifferentDates>>,
+    #[serde(default)]
     airports: Option<Vec<StartFromOtherAirportOption>>,
 }
 
@@ -1079,5 +1083,26 @@ mod tests {
 
         assert!(result.is_ok());
         Ok(())
+    }
+
+    #[test]
+    fn test_hour_can_be_empty() {
+        let hour_str = "{}".to_string();
+        let hour = serde_json::from_str::<Hour>(&hour_str);
+        assert!(hour.is_ok());
+        let parsed = serde_json::to_string(&hour.unwrap()).unwrap();
+        let res = r#"{"hour":null,"minute":0}"#.to_string();
+        assert_eq!(parsed, res);
+    }
+
+    #[test]
+    fn test_cheaper_travel_different_places_can_be_empty() {
+        let cheaper_travel_str = "{}".to_string();
+        let cheaper_travel =
+            serde_json::from_str::<CheaperTravelDifferentPlaces>(&cheaper_travel_str);
+        assert!(cheaper_travel.is_ok());
+        let parsed = serde_json::to_string(&cheaper_travel.unwrap()).unwrap();
+        let res = r#"{"dates":null,"airports":null}"#.to_string();
+        assert_eq!(parsed, res);
     }
 }


### PR DESCRIPTION
This pull request refactors the code by adding default serde attributes to the Hour and CheaperTravelDifferentPlaces structs. This ensures that the hour field in the Hour struct and the dates and airports fields in the CheaperTravelDifferentPlaces struct can be empty when deserializing from JSON.

Fixes errors encountered from time to time for some requests.

Fixes #22