### PR TITLE
test: add wire protocol, locale, booking URL, and fixture regression …

### DIFF
--- a/src/parsers/request/flight_request.rs
+++ b/src/parsers/request/flight_request.rs
@@ -1124,4 +1124,177 @@ mod tests {
         let with_str = leg_with_emissions.serialize_to_web().unwrap();
         assert!(with_str.ends_with(",[1],3]"), "with emissions: {with_str}");
     }
+
+    // -----------------------------------------------------------------------
+    // Wire protocol: airline-include filter appears in the request body
+    // -----------------------------------------------------------------------
+
+    /// When `airlines_include` is set, the filter string (e.g. `LX`) must
+    /// appear in the serialised `f.req` body.
+    #[test]
+    fn request_body_contains_airline_include_filter() -> Result<()> {
+        use crate::parsers::common::AirlineCode;
+
+        let lx = AirlineFilter::Airline(AirlineCode::new("LX").unwrap());
+        let departure = Location {
+            loc_identifier: "LUX".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: None,
+        };
+        let arrival = Location {
+            loc_identifier: "NRT".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: None,
+        };
+        let frontend_version = "boq_travel-frontend-ui_20240110.02_p0".to_string();
+        let fixed_flights = FixedFlights::new(1);
+        let times = FlightTimes::default();
+
+        let opts = FlightRequestOptions {
+            departing_city: core::slice::from_ref(&departure),
+            arriving_city: core::slice::from_ref(&arrival),
+            date_start: "2025-06-01",
+            date_return: None,
+            travellers: Travelers::new(vec![1, 0, 0, 0])?,
+            travel_class: &TravelClass::Economy,
+            stop_option: &StopOptions::All,
+            departing_times: &times,
+            return_times: &times,
+            stopover_max: &StopoverDuration::UNLIMITED,
+            stopover_min: &StopoverDuration::UNLIMITED,
+            duration_max: &TotalDuration::UNLIMITED,
+            frontend_version: &frontend_version,
+            fixed_flights: &fixed_flights,
+            language: "en",
+            country: "GB",
+            sort_order: &SortOrder::Best,
+            airlines_include: &[lx],
+            airlines_exclude: &[],
+            connecting_airports: &[],
+            lower_emissions: false,
+        };
+        let req: RequestBody = (&opts).try_into()?;
+        assert!(req.body.contains("LX"), "body should contain airline code LX");
+        Ok(())
+    }
+
+    /// When `stop_option` is `NonStop`, the stops value in the body must be `1`.
+    #[test]
+    fn request_body_nonstop_filter_sets_stop_value_1() -> Result<()> {
+        let departure = Location {
+            loc_identifier: "LHR".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: None,
+        };
+        let arrival = Location {
+            loc_identifier: "JFK".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: None,
+        };
+        let times = FlightTimes::default();
+        let leg = SingleLegStruct {
+            departure: vec![vec![&departure]],
+            arrival: vec![vec![&arrival]],
+            stop_options: &StopOptions::NoStop,
+            date: "2025-06-01",
+            times: &times,
+            stopover_max: &StopoverDuration::UNLIMITED,
+            stopover_min: &StopoverDuration::UNLIMITED,
+            duration_max: &TotalDuration::UNLIMITED,
+            chosen_itinerary: None,
+            airlines_include: &[],
+            airlines_exclude: &[],
+            connecting_airports: &[],
+            lower_emissions: false,
+        };
+        let serialised = leg.serialize_to_web()?;
+        // position [3] is the stop option; NonStop → 1
+        assert!(
+            serialised.contains(",1,null,null,"),
+            "nonstop leg should contain ',1,null,null,' at stop-option position: {serialised}"
+        );
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Locale / language parameter tests
+    // -----------------------------------------------------------------------
+
+    /// `language="fr"` + `country="FR"` must produce `hl=fr-FR` in the URL.
+    #[test]
+    fn request_url_contains_hl_fr_fr() -> Result<()> {
+        let req = make_minimal_request("fr", "FR")?;
+        assert!(
+            req.url.contains("hl=fr-FR"),
+            "URL should contain hl=fr-FR, got: {}",
+            req.url
+        );
+        Ok(())
+    }
+
+    /// `language="de"` + `country="DE"` must produce `hl=de-DE` in the URL.
+    #[test]
+    fn request_url_contains_hl_de_de() -> Result<()> {
+        let req = make_minimal_request("de", "DE")?;
+        assert!(
+            req.url.contains("hl=de-DE"),
+            "URL should contain hl=de-DE, got: {}",
+            req.url
+        );
+        Ok(())
+    }
+
+    /// `country` stored in lowercase is uppercased in the URL.
+    #[test]
+    fn request_url_uppercases_country_code() -> Result<()> {
+        let req = make_minimal_request("en", "gb")?;
+        assert!(
+            req.url.contains("hl=en-GB"),
+            "country 'gb' should be uppercased to 'GB' in URL: {}",
+            req.url
+        );
+        Ok(())
+    }
+
+    /// Helper: build a minimal `RequestBody` with the given locale params.
+    fn make_minimal_request(language: &str, country: &str) -> Result<RequestBody> {
+        let departure = Location {
+            loc_identifier: "LHR".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: None,
+        };
+        let arrival = Location {
+            loc_identifier: "JFK".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: None,
+        };
+        let times = FlightTimes::default();
+        let frontend_version = "boq_travel-frontend-ui_20240110.02_p0".to_string();
+        let fixed_flights = FixedFlights::new(1);
+
+        let opts = FlightRequestOptions {
+            departing_city: core::slice::from_ref(&departure),
+            arriving_city: core::slice::from_ref(&arrival),
+            date_start: "2025-06-01",
+            date_return: None,
+            travellers: Travelers::new(vec![1, 0, 0, 0])?,
+            travel_class: &TravelClass::Economy,
+            stop_option: &StopOptions::All,
+            departing_times: &times,
+            return_times: &times,
+            stopover_max: &StopoverDuration::UNLIMITED,
+            stopover_min: &StopoverDuration::UNLIMITED,
+            duration_max: &TotalDuration::UNLIMITED,
+            frontend_version: &frontend_version,
+            fixed_flights: &fixed_flights,
+            language,
+            country,
+            sort_order: &SortOrder::Best,
+            airlines_include: &[],
+            airlines_exclude: &[],
+            connecting_airports: &[],
+            lower_emissions: false,
+        };
+        (&opts).try_into()
+    }
 }

--- a/src/parsers/response/flight_response.rs
+++ b/src/parsers/response/flight_response.rs
@@ -1120,4 +1120,116 @@ mod tests {
         let flights = container.get_all_flights();
         assert_eq!(flights.len(), 1);
     }
+
+    // -----------------------------------------------------------------------
+    // Structural regression tests: parse real fixtures and check invariants
+    //
+    // The `lux_*_oneway.txt` fixtures are already-decoded inner JSON
+    // (RawResponse format), not the raw multi-line wrb.fr envelope.
+    // We parse them with serde_json directly and exercise the helper methods.
+    // -----------------------------------------------------------------------
+
+    fn parse_fixture(path: &str) -> RawResponse {
+        let body = fs::read_to_string(path)
+            .unwrap_or_else(|_| panic!("cannot read fixture: {path}"));
+        serde_json::from_str(&body)
+            .unwrap_or_else(|e| panic!("failed to parse {path}: {e}"))
+    }
+
+    /// `lux_tokyo_oneway.txt` parses without error and contains at least one flight.
+    #[test]
+    fn fixture_lux_tokyo_oneway_non_empty_flights() {
+        let resp = parse_fixture("test_files/lux_tokyo_oneway.txt");
+        let flights = resp.maybe_get_all_flights().unwrap_or_default();
+        assert!(!flights.is_empty(), "expected at least one flight in lux_tokyo fixture");
+    }
+
+    /// All airline codes in the Tokyo fixture are non-empty.
+    #[test]
+    fn fixture_lux_tokyo_oneway_all_airlines_non_empty() {
+        let resp = parse_fixture("test_files/lux_tokyo_oneway.txt");
+        for flight in resp.maybe_get_all_flights().unwrap_or_default() {
+            assert!(
+                !flight.itinerary.flight_by.is_empty(),
+                "flight_by should be non-empty"
+            );
+        }
+    }
+
+    /// All departure tokens in the Tokyo fixture are non-empty.
+    #[test]
+    fn fixture_lux_tokyo_oneway_all_departure_tokens_non_empty() {
+        let resp = parse_fixture("test_files/lux_tokyo_oneway.txt");
+        for flight in resp.maybe_get_all_flights().unwrap_or_default() {
+            assert!(
+                !flight.itinerary_cost.departure_token.is_empty(),
+                "departure_token should be non-empty"
+            );
+        }
+    }
+
+    /// All total_time_minutes values in the Tokyo fixture are positive.
+    #[test]
+    fn fixture_lux_tokyo_oneway_total_time_positive() {
+        let resp = parse_fixture("test_files/lux_tokyo_oneway.txt");
+        for flight in resp.maybe_get_all_flights().unwrap_or_default() {
+            assert!(
+                flight.itinerary.total_time_minutes > 0,
+                "total_time_minutes must be > 0"
+            );
+        }
+    }
+
+    /// All airport codes in the Tokyo fixture are 3-char uppercase ASCII.
+    #[test]
+    fn fixture_lux_tokyo_oneway_airport_codes_are_3char_uppercase() {
+        let resp = parse_fixture("test_files/lux_tokyo_oneway.txt");
+        for flight in resp.maybe_get_all_flights().unwrap_or_default() {
+            for leg in &flight.itinerary.flight_details {
+                let dep = &leg.departure_airport_code;
+                let arr = &leg.destination_airport_code;
+                // Airport codes are 3-char uppercase ASCII; city identifiers start with /
+                if !dep.starts_with('/') {
+                    assert_eq!(dep.len(), 3, "departure code '{dep}' should be 3 chars");
+                    assert!(dep.chars().all(|c| c.is_ascii_uppercase()), "departure code '{dep}' should be uppercase ASCII");
+                }
+                if !arr.starts_with('/') {
+                    assert_eq!(arr.len(), 3, "arrival code '{arr}' should be 3 chars");
+                    assert!(arr.chars().all(|c| c.is_ascii_uppercase()), "arrival code '{arr}' should be uppercase ASCII");
+                }
+            }
+        }
+    }
+
+    /// `lux_dubai_oneway.txt` parses without error and contains at least one flight.
+    #[test]
+    fn fixture_lux_dubai_oneway_non_empty_flights() {
+        let resp = parse_fixture("test_files/lux_dubai_oneway.txt");
+        let flights = resp.maybe_get_all_flights().unwrap_or_default();
+        assert!(!flights.is_empty(), "expected at least one flight in lux_dubai fixture");
+    }
+
+    /// All departure tokens in the Dubai fixture are non-empty.
+    #[test]
+    fn fixture_lux_dubai_oneway_all_departure_tokens_non_empty() {
+        let resp = parse_fixture("test_files/lux_dubai_oneway.txt");
+        for flight in resp.maybe_get_all_flights().unwrap_or_default() {
+            assert!(
+                !flight.itinerary_cost.departure_token.is_empty(),
+                "departure_token should be non-empty"
+            );
+        }
+    }
+
+    /// All total_time_minutes values in the Dubai fixture are positive.
+    #[test]
+    fn fixture_lux_dubai_oneway_total_time_positive() {
+        let resp = parse_fixture("test_files/lux_dubai_oneway.txt");
+        for flight in resp.maybe_get_all_flights().unwrap_or_default() {
+            assert!(
+                flight.itinerary.total_time_minutes > 0,
+                "total_time_minutes must be > 0"
+            );
+        }
+    }
 }

--- a/src/requests/api.rs
+++ b/src/requests/api.rs
@@ -810,4 +810,56 @@ mod tests {
         // max(1,1) == 1, so range 0..1 has a single iteration
         assert_eq!(cfg.max_attempts.max(1), 1);
     }
+
+    // -----------------------------------------------------------------------
+    // Booking URL: meta-refresh extraction logic (offline, structural)
+    // -----------------------------------------------------------------------
+
+    /// The regex used in `resolve_booking_url` extracts the URL from a
+    /// single-quoted meta-refresh response.
+    #[test]
+    fn booking_url_regex_extracts_single_quoted_url() {
+        let html = r#"<meta content="0;url='https://example.com/book?foo=bar'" http-equiv="refresh">"#;
+        let re = Regex::new(r#"(?i)url=['"]([^'"]+)['"]"#).unwrap();
+        let extracted = re
+            .captures(html)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str().to_string());
+        assert_eq!(extracted, Some("https://example.com/book?foo=bar".to_string()));
+    }
+
+    /// The same regex handles double-quoted url values.
+    #[test]
+    fn booking_url_regex_extracts_double_quoted_url() {
+        let _html = r#"<meta content="0;url=&quot;https://airline.com/booking?ref=123&amp;src=gf&quot;" http-equiv="refresh">"#;
+        // double-quote form uses literal &quot; — after HTML-decode the url= value is double-quoted
+        // here we test the raw pattern against a double-quoted variant directly
+        let html2 = r#"<meta content='0;url="https://airline.com/booking?ref=123"' http-equiv="refresh">"#;
+        let re = Regex::new(r#"(?i)url=['"]([^'"]+)['"]"#).unwrap();
+        let extracted = re
+            .captures(html2)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str().to_string());
+        assert_eq!(extracted, Some("https://airline.com/booking?ref=123".to_string()));
+    }
+
+    /// `&amp;` in the extracted URL is decoded to `&`.
+    #[test]
+    fn booking_url_amp_entity_is_decoded() {
+        let raw = "https://example.com/book?foo=1&amp;bar=2";
+        let decoded = raw.replace("&amp;", "&");
+        assert_eq!(decoded, "https://example.com/book?foo=1&bar=2");
+    }
+
+    /// When the response contains no meta-refresh, the extraction returns `None`.
+    #[test]
+    fn booking_url_regex_returns_none_on_missing_url() {
+        let html = "<html><head><title>Error</title></head><body>Not found</body></html>";
+        let re = Regex::new(r#"(?i)url=['"]([^'"]+)['"]"#).unwrap();
+        let extracted = re
+            .captures(html)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str().to_string());
+        assert_eq!(extracted, None);
+    }
 }


### PR DESCRIPTION
…tests

- Wire protocol: verify airline-include filter and nonstop stop-option appear correctly in the serialised request body
- Locale: assert hl=fr-FR, hl=de-DE, and lowercase country uppercasing in the generated request URL
- Booking URL: test the meta-refresh regex extraction logic in isolation, including single/double quotes and &amp; decoding
- Fixture regression: parse lux_tokyo_oneway.txt and lux_dubai_oneway.txt and check non-empty flight list, non-empty airline codes, non-empty departure tokens, positive total_time_minutes, and 3-char uppercase airport codes

17 new #[test] functions; all offline, no network required. 152 → 169 lib tests; clippy --all-targets -D warnings clean.