### PR TITLE
fix(cli): show subcommand help on missing args; warn on rail station …

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ gflights search --from MXP --to NRT --date 2026-09-01 --return 2026-09-15 \
   --min-layover 60 --max-layover 180 \
   --lower-emissions --sort price --format json
 
+# Multi-city (open-jaw) search
+gflights mcity --leg LUX FCO 2026-09-10 --leg FCO MAD 2026-09-13 --leg MAD LUX 2026-09-17
+
 # Price graph (cheapest fare per day over 3 months)
 gflights graph --from LHR --to JFK --date 2026-08-01 --months 3
 
@@ -209,6 +212,35 @@ Run with:
 
 ```sh
 cargo run --example graph
+```
+
+### Multi-city (open-jaw) search
+
+```rust
+use gflights::requests::{api::ApiClient, config::MultiCityConfig};
+use chrono::NaiveDate;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let client = ApiClient::new().await;
+
+    let config = MultiCityConfig::builder()
+        .add_leg("LUX", "FCO", NaiveDate::from_ymd_opt(2026, 9, 10).unwrap(), &client).await?
+        .add_leg("FCO", "MAD", NaiveDate::from_ymd_opt(2026, 9, 13).unwrap(), &client).await?
+        .add_leg("MAD", "LUX", NaiveDate::from_ymd_opt(2026, 9, 17).unwrap(), &client).await?
+        .build()?;
+
+    let results = client.request_multi_city_flights(&config).await?;
+    let flights = results.get_all_flights();
+    println!("Found {} flight options across {} legs", flights.len(), config.legs.len());
+    Ok(())
+}
+```
+
+Run with:
+
+```sh
+cargo run --example multi_city
 ```
 
 ---

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -202,18 +202,13 @@ pub async fn run_repl(client: &ApiClient) -> Result<()> {
                             eprintln!("Error: {e:#}");
                         }
                     }
-                    // clap would normally call process::exit for --help / --version;
-                    // intercept those kinds and just print without exiting the REPL.
-                    Err(e)
-                        if matches!(
-                            e.kind(),
-                            clap::error::ErrorKind::DisplayHelp
-                                | clap::error::ErrorKind::DisplayVersion
-                        ) =>
-                    {
-                        print!("{e}");
+                    // For all clap errors (missing required args, --help, --version,
+                    // unknown flags, …) use clap's own formatter so the user sees
+                    // coloured output with a "Usage:" hint instead of a raw error
+                    // string.  We never call process::exit here so the REPL continues.
+                    Err(e) => {
+                        e.print().unwrap_or_default();
                     }
-                    Err(e) => eprintln!("{e}"),
                 }
             }
             Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => break,
@@ -365,6 +360,12 @@ mod tests {
         // search without any arguments should error (all three of --from/--to/--date required)
         let result = parse(&["search"]);
         assert!(result.is_err(), "search without required args should error");
+        let e = result.unwrap_err();
+        assert!(
+            matches!(e.kind(), ErrorKind::MissingRequiredArgument),
+            "expected MissingRequiredArgument, got: {:?}",
+            e.kind()
+        );
     }
 
     #[test]

--- a/src/requests/config/builder.rs
+++ b/src/requests/config/builder.rs
@@ -310,6 +310,13 @@ impl ConfigBuilder {
 
 async fn get_location(location: &str, client: &ApiClient) -> Result<Location, anyhow::Error> {
     let departure = if location.len() == 3 && location.chars().all(char::is_uppercase) {
+        if location.starts_with('X') {
+            eprintln!(
+                "Warning: '{}' looks like a rail station code. \
+                 If you meant a city, use the full name (e.g. 'Rome').",
+                location
+            );
+        }
         Location {
             loc_identifier: location.to_owned(),
             loc_type: PlaceType::Airport,
@@ -462,5 +469,32 @@ mod tests {
         assert!(cfg.lower_emissions);
         assert!(matches!(cfg.stopover_min, StopoverDuration::Minutes(60)));
         assert!(matches!(cfg.stopover_max, StopoverDuration::Minutes(180)));
+    }
+
+    /// `departure_location` accepts an X-prefixed code (e.g. a rail station code)
+    /// without error — the warning is printed to stderr but the Location is created
+    /// and the Config builds successfully.  The warning path is exercised via the
+    /// async `departure()` helper in live tests; here we verify the code path that
+    /// already has a `Location` does not reject X-prefix codes.
+    #[test]
+    fn x_prefixed_location_builds_without_error() {
+        let xrj = Location {
+            loc_identifier: "XRJ".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: Some("XRJ".to_owned()),
+        };
+        let xvq = Location {
+            loc_identifier: "XVQ".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: Some("XVQ".to_owned()),
+        };
+        let cfg = Config::builder()
+            .departing_date(future_date(30))
+            .departure_location(xrj)
+            .destination_location(xvq)
+            .build()
+            .expect("X-prefixed location codes must not be rejected by Config::build");
+        assert_eq!(cfg.departure[0].loc_identifier, "XRJ");
+        assert_eq!(cfg.destination[0].loc_identifier, "XVQ");
     }
 }

--- a/tests/live_api.rs
+++ b/tests/live_api.rs
@@ -1150,3 +1150,42 @@ async fn invalid_iata_xxx_does_not_panic() -> Result<()> {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Rail station / non-airport IATA codes
+// ---------------------------------------------------------------------------
+
+/// Rail station codes (Amadeus X-prefix convention, e.g. XRJ = Rome Termini,
+/// XVQ = Venice Santa Lucia) must not cause panics or unrecoverable errors.
+///
+/// Google Flights does not know about rail codes so results will typically be
+/// empty, but the API call must succeed (or return a graceful typed error) and
+/// `get_all_flights()` must return an empty `Vec` rather than panicking.
+#[tokio::test]
+#[ignore = "requires live network"]
+async fn train_station_iata_returns_empty_or_graceful() -> Result<()> {
+    require_live!();
+    let client = shared_client().await;
+
+    // XRJ = Rome Termini rail code; XVQ = Venice Santa Lucia rail code.
+    let config = Config::builder()
+        .departure("XRJ", client)
+        .await?
+        .destination("XVQ", client)
+        .await?
+        .departing_date(days_from_now(14))
+        .build()?;
+
+    // The request must not panic; either an Ok (possibly empty) or a typed Err.
+    match client.request_flights(&config).await {
+        Ok(r) => {
+            // Accessing get_all_flights() must not panic even for empty results.
+            let _ = r.get_all_flights();
+        }
+        Err(_) => {
+            // A graceful typed error is also an acceptable outcome.
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
…codes

In the REPL, all clap errors now route through e.print() instead of the old split-arm pattern, so typing a subcommand name with no args (e.g. `search`, `mcity`) shows clap's coloured Usage: hint rather than a bare error string, and the REPL never calls process::exit.

In get_location(), a code starting with 'X' (Amadeus rail-station prefix) now prints a stderr warning that directs the user to supply a city name instead; the code is still passed through so the API can return an empty result gracefully.

Also adds unit tests: repl_parse_missing_required_returns_error now asserts ErrorKind::MissingRequiredArgument, and
x_prefixed_location_builds_without_error confirms X-prefixed codes do not cause Config::build to fail. A live #[ignore] test train_station_iata_returns_empty_or_graceful covers the end-to-end path.