### PR TITLE
feat(examples): add cheapest_dates and offer examples; document parity rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,29 @@ If coverage drops below 80%, add tests before merging.
 
 ---
 
+## Examples parity rule
+
+Every public-facing feature must have a corresponding example in `examples/`.
+
+| Feature | Example file |
+|---|---|
+| Flight search + offers + booking URL | `examples/flights.rs` |
+| Price graph | `examples/graph.rs` |
+| Date grid | `examples/date_grid.rs` |
+| Cheapest dates (one-way + round-trip) | `examples/cheapest_dates.rs` |
+| Booking offers + URL resolution | `examples/offer.rs` |
+| Multi-city search | `examples/multi_city.rs` |
+| Explore destinations | `examples/explore.rs` |
+
+When adding a new public API method, add or update the relevant example. All examples guard network calls behind `RUN_LIVE=1` so `cargo test --examples` passes offline.
+
+```sh
+cargo build --examples                   # must compile clean
+RUN_LIVE=1 cargo run --example <name>    # smoke-test with network
+```
+
+---
+
 ## Python bindings parity rule
 
 Whenever `src/` (the Rust crate) changes, update `gflights-py/` to match:

--- a/examples/cheapest_dates.rs
+++ b/examples/cheapest_dates.rs
@@ -1,0 +1,96 @@
+//! Example: find the cheapest departure dates for a route.
+//!
+//! Demonstrates both one-way mode (price calendar) and round-trip mode (date
+//! grid) using [`ApiClient::cheapest_dates`].
+//!
+//! Run with live network access:
+//!   RUN_LIVE=1 cargo run --example cheapest_dates
+//!
+//! Without RUN_LIVE the example exits early with a message so that `cargo test`
+//! does not perform network requests.
+
+use chrono::{Months, NaiveDate};
+use gflights::parsers::common::{Location, PlaceType};
+use gflights::requests::api::ApiClient;
+use gflights::requests::config::Config;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("gflights=info")),
+        )
+        .init();
+
+    if std::env::var("RUN_LIVE").is_err() {
+        println!("Set RUN_LIVE=1 to run this example with live network access.");
+        return Ok(());
+    }
+
+    let client = ApiClient::new().await;
+
+    // Build a config for the LUX → JFK route starting from a fixed date.
+    // Using departure_location / destination_location directly avoids an extra
+    // city-lookup API call when you already have the IATA code.
+    let config = Config::builder()
+        .departure_location(Location {
+            loc_identifier: "LUX".into(),
+            loc_type: PlaceType::Airport,
+            location_name: Some("Luxembourg".into()),
+        })
+        .destination_location(Location {
+            loc_identifier: "JFK".into(),
+            loc_type: PlaceType::Airport,
+            location_name: Some("New York".into()),
+        })
+        .departing_date(NaiveDate::from_ymd_opt(2026, 9, 1).unwrap())
+        .build()?;
+
+    // -------------------------------------------------------------------------
+    // One-way mode: cheapest single dates over the next 3 months
+    // -------------------------------------------------------------------------
+    println!("=== Cheapest one-way dates (LUX → JFK, next 3 months) ===");
+    let oneway = client.cheapest_dates(&config, Months::new(3), None).await?;
+
+    if oneway.is_empty() {
+        println!("  No dates found.");
+    } else {
+        for date in oneway.iter().take(5) {
+            println!("  Depart {}  →  {} EUR", date.departure_date, date.price);
+        }
+        if oneway.len() > 5 {
+            println!("  … and {} more", oneway.len() - 5);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Round-trip mode: cheapest 7-night trips over the next 3 months
+    // -------------------------------------------------------------------------
+    println!();
+    println!("=== Cheapest 7-night round trips (LUX ⇄ JFK, next 3 months) ===");
+    let roundtrip = client
+        .cheapest_dates(&config, Months::new(3), Some(7))
+        .await?;
+
+    if roundtrip.is_empty() {
+        println!("  No date pairs found.");
+    } else {
+        for pair in roundtrip.iter().take(5) {
+            let ret = pair
+                .return_date
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "?".into());
+            println!(
+                "  Depart {}  Return {}  →  {} EUR",
+                pair.departure_date, ret, pair.price
+            );
+        }
+        if roundtrip.len() > 5 {
+            println!("  … and {} more", roundtrip.len() - 5);
+        }
+    }
+
+    Ok(())
+}

--- a/examples/offer.rs
+++ b/examples/offer.rs
@@ -1,0 +1,128 @@
+//! Example: fetch booking offers and resolve a deep-link URL.
+//!
+//! Shows the two-step flow: search for flights, pick one, then call
+//! [`ApiClient::request_offer`] to get airline-specific prices and booking
+//! links, and [`ApiClient::resolve_booking_url`] to turn a click token into a
+//! real URL.
+//!
+//! Run with live network access:
+//!   RUN_LIVE=1 cargo run --example offer
+//!
+//! Without RUN_LIVE the example exits early with a message so that `cargo test`
+//! does not perform network requests.
+
+use anyhow::Context;
+use chrono::{Duration, Utc};
+use gflights::requests::api::ApiClient;
+use gflights::requests::config::Config;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("gflights=info")),
+        )
+        .init();
+
+    if std::env::var("RUN_LIVE").is_err() {
+        println!("Set RUN_LIVE=1 to run this example with live network access.");
+        return Ok(());
+    }
+
+    let client = ApiClient::new().await;
+    let today = Utc::now().date_naive();
+
+    // -------------------------------------------------------------------------
+    // Step 1: search for flights and pick the first result
+    // -------------------------------------------------------------------------
+    let config = Config::builder()
+        .departure("LHR", &client)
+        .await
+        .context("departure lookup")?
+        .destination("JFK", &client)
+        .await
+        .context("destination lookup")?
+        .departing_date(today + Duration::days(30))
+        .build()
+        .context("build config")?;
+
+    let search = client
+        .request_flights(&config)
+        .await
+        .context("flight search")?;
+
+    let first = search
+        .responses
+        .iter()
+        .filter_map(|r| r.maybe_get_all_flights())
+        .flatten()
+        .next()
+        .context("no flights found")?;
+
+    println!(
+        "Selected flight: {} · {} min · {} stop(s)",
+        first.itinerary.flight_by,
+        first.itinerary.total_time_minutes,
+        first.itinerary.stop_count(),
+    );
+
+    // Lock in the selected flight so the offer request knows which itinerary
+    // we want offers for.
+    config.fixed_flights.add_element(first)?;
+
+    // -------------------------------------------------------------------------
+    // Step 2: request booking offers for that itinerary
+    // -------------------------------------------------------------------------
+    let offers_response = client
+        .request_offer(&config)
+        .await
+        .context("offer request")?;
+
+    let mut offer_groups: Vec<_> = offers_response
+        .response
+        .iter()
+        .flat_map(|r| &r.offers)
+        .filter(|o| o.price.is_some())
+        .collect();
+
+    offer_groups.sort_by_key(|o| o.price.unwrap_or(i32::MAX));
+
+    if offer_groups.is_empty() {
+        println!("No offers returned for this itinerary.");
+        return Ok(());
+    }
+
+    println!("\nBooking offers (sorted cheapest first):");
+
+    for offer in &offer_groups {
+        let price = offer.price.unwrap_or(0);
+        let airlines = offer.airline_names.join(", ");
+        println!("  {airlines}  →  {price} EUR");
+
+        // -------------------------------------------------------------------------
+        // Step 3: resolve a click token to a real booking URL
+        // -------------------------------------------------------------------------
+        if let Some(token) = offer.click_token.as_deref() {
+            match client.resolve_booking_url(token).await {
+                Ok(url) => println!("    URL: {url}"),
+                Err(e) => println!("    (URL resolution failed: {e})"),
+            }
+        } else {
+            // Some offers have sub-options (e.g. different travel agencies).
+            for sub in offer.sub_options.iter().take(2) {
+                let sub_price = sub.price.map(|p| format!("{p} EUR")).unwrap_or_default();
+                let partners = sub.partner_names.join(", ");
+                if let Some(token) = sub.click_token.as_deref() {
+                    match client.resolve_booking_url(token).await {
+                        Ok(url) => println!("    [{partners}  {sub_price}]  {url}"),
+                        Err(e) => println!("    [{partners}] (failed: {e})"),
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add `examples/cheapest_dates.rs` — demonstrates `ApiClient::cheapest_dates()` in both one-way mode (price calendar scan) and round-trip mode (date-grid, returns paired dep+ret dates)
- Add `examples/offer.rs` — demonstrates the three-step booking flow: search → lock in a flight → `request_offer()` → `resolve_booking_url()` for each click token
- Add **Examples parity rule** to `CLAUDE.md` requiring every public-facing feature to have a corresponding example, with a table of current coverage

## Notes

- Both new examples guard network calls behind `RUN_LIVE=1` so `cargo build --examples` passes offline (same pattern as existing examples)
- `flights.rs` already covered offers partially; `offer.rs` makes it a focused, standalone reference
- All examples compile clean; 190 lib tests + 25 CLI tests unchanged
