### PR TITLE
fix(api,explore): bound date-grid concurrency, retry on EOF, fix explore airport

### DIFF
--- a/gflights-py/gflights/_gflights.pyi
+++ b/gflights-py/gflights/_gflights.pyi
@@ -70,6 +70,7 @@ class ExploreResult:
     lng: float
     image_url: Optional[str]
     nearest_airport: str
+    flight_airport: Optional[str]
     date_from: Optional[str]
     date_to: Optional[str]
     price: Optional[int]

--- a/gflights-py/src/lib.rs
+++ b/gflights-py/src/lib.rs
@@ -329,8 +329,14 @@ pub struct ExploreResult {
     pub lng: f64,
     /// URL of a cover photo, or ``None``.
     pub image_url: Option<String>,
-    /// IATA code of the nearest airport.
+    /// IATA code of the nearest airport to the destination (geographic label).
     pub nearest_airport: String,
+    /// IATA code of the airport the priced flight actually lands at, or ``None``.
+    ///
+    /// Prefer this over ``nearest_airport`` when booking or displaying to users —
+    /// they can differ when Google prices a flight to a secondary airport
+    /// (e.g. ``nearest_airport="NCE"`` but ``flight_airport="MRS"``).
+    pub flight_airport: Option<String>,
     /// Earliest outbound departure date as ``"YYYY-MM-DD"``, or ``None``.
     pub date_from: Option<String>,
     /// Latest return date as ``"YYYY-MM-DD"``, or ``None``.
@@ -995,6 +1001,7 @@ impl GFlights {
                                 lng: r.coords.1,
                                 image_url: r.image_url,
                                 nearest_airport: r.nearest_airport,
+                                flight_airport: r.flight_airport,
                                 date_from: r.date_from.map(|d| d.to_string()),
                                 date_to: r.date_to.map(|d| d.to_string()),
                                 price: r.price,

--- a/src/bin/cli/explore.rs
+++ b/src/bin/cli/explore.rs
@@ -275,7 +275,7 @@ pub async fn cmd_explore(args: ExploreArgs, client: &ApiClient) -> Result<()> {
                     "{:<20}  {:<12}  {:<5}  {:>6}  {:<8}  {:>5}  {}",
                     truncate(&r.name, 20),
                     truncate(&r.country, 12),
-                    r.nearest_airport,
+                    r.flight_airport.as_deref().unwrap_or(&r.nearest_airport),
                     price_str,
                     airline_str,
                     stops_str,

--- a/src/parsers/response/explore_response.rs
+++ b/src/parsers/response/explore_response.rs
@@ -166,7 +166,7 @@ pub fn parse_explore_response(raw: &str) -> Result<Vec<ExploreResult>> {
                     }
                 }
 
-                // [6] = ["airline_code", "airline_name", stops, duration_mins, ...]
+                // [6] = ["airline_code", "airline_name", stops, duration_mins, null, "dest_iata", ...]
                 if let Some(flight_detail) = get_idx::<Vec<Value>>(entry_arr, 6) {
                     dest.airline = get_idx(&flight_detail, 0);
                     if let Some(s) = get_idx::<i64>(&flight_detail, 2) {
@@ -175,6 +175,8 @@ pub fn parse_explore_response(raw: &str) -> Result<Vec<ExploreResult>> {
                     if let Some(d) = get_idx::<i64>(&flight_detail, 3) {
                         dest.flight_duration_minutes = Some(d.max(0) as u32);
                     }
+                    // [5] = actual destination airport IATA (may differ from nearest_airport)
+                    dest.flight_airport = get_idx(&flight_detail, 5);
                 }
 
                 // [15] = [[null, accommodation_price_nightly]]
@@ -249,6 +251,7 @@ fn parse_destination_entry(v: Value) -> Result<ExploreResult> {
         coords,
         image_url,
         nearest_airport,
+        flight_airport: None, // filled in from chunk 2 [6][5]
         date_from,
         date_to,
         price: None,

--- a/src/requests/config/explore.rs
+++ b/src/requests/config/explore.rs
@@ -309,8 +309,15 @@ pub struct ExploreResult {
     pub coords: (f64, f64),
     /// URL of a cover photo (if available).
     pub image_url: Option<String>,
-    /// IATA code of the nearest airport.
+    /// IATA code of the nearest airport to the destination (geographic label).
     pub nearest_airport: String,
+    /// IATA code of the airport the priced flight actually lands at.
+    ///
+    /// For multi-airport cities this often differs from [`Self::nearest_airport`]:
+    /// e.g. Verdon Gorge has `nearest_airport = "NCE"` but cheap Ryanair flights
+    /// land at `flight_airport = "MRS"`.  Prefer this field when booking or when
+    /// showing the user which airport to fly into.
+    pub flight_airport: Option<String>,
     /// Earliest available outbound departure date.
     pub date_from: Option<chrono::NaiveDate>,
     /// Latest available return date (round-trip) or arrival date (one-way).


### PR DESCRIPTION
## Summary

### `api.rs` — date-grid concurrency
- `buffer_unordered(6)` was batching 46 chunks in groups of 6 → 8 serial batches × ~10 s = ~80 s
- Replacing with `join_all` exposed the real issue: rate × latency ≈ 10 req/s × 5 s = ~50 concurrent connections, which triggered Google sending EOF mid-stream on some responses
- Fix: `buffer_unordered(8)` caps in-flight connections at 8 (~30–40 s for 46 chunks, no EOF)
- Added per-chunk retry loop for body-read errors (EOF, connection-reset) that occur after `do_request` returns the `Response` handle

### `explore` — actual flight airport
- `nearest_airport` (chunk 1 `[15]`) is a geographic label and can differ from the actual destination airport (e.g. `nearest_airport=NCE` but flight lands at `MRS`)
- Parse `flight_airport` from chunk 2 `[6][5]` (`dest_iata`)
- CLI ARPT column now shows `flight_airport`, falling back to `nearest_airport`
- Python bindings (`ExploreResult.flight_airport: Optional[str]`) and `.pyi` stub updated

## Test plan

- [ ] `cargo test --lib` — 192 tests pass
- [ ] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [ ] Live: `gflights explore --interest climbing --from LUX --duration week --month 9 --budget 150` — Verdon Gorge shows MRS instead of NCE
- [ ] Live: `$env:RUN_LIVE=1; cargo run --example cheapest_dates` — round-trip section completes in ~30-40 s without EOF errors