### PR TITLE
docs: update README and CHANGELOG for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,56 +7,115 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*(pending PR merges)*
+
+---
+
+## [0.2.0] — 2026-06-03
+
 ### Added
 
-- **`total_time_minutes`** field on `Itinerary` (index 9 of raw response).
-- **`connection_info`** field on `Itinerary` — per-layover `ConnectionInfo` structs
-  (connection time, arrival/departure airport codes and city names).
-- **`stop_count()`** method on `Itinerary` — derived from `connection_info` length.
-- **`leg_duration_minutes`** field on `FlightInfo` (individual leg duration).
-- **`emissions`** field on `Itinerary` — CO2 data (`Emissions` struct with
-  `co2_this_flight_g`, `co2_typical_route_g`, `co2_lowest_route_g`, and
-  `emission_vs_average_percent`).
-- **`language` / `country`** fields on `Config` and `ConfigBuilder` — removes
-  hard-coded `hl=en-GB` locale; default remains `en`/`GB`.
+#### Core library
+
+- **`gflights explore`** — `GetExploreDestinations` endpoint + CLI `explore` subcommand.
+  Returns `Vec<ExploreResult>` with destination name, country, airport codes, price, dates,
+  airline, CO₂, and accommodation price.
+  - `ExploreResult::flight_airport` — actual flight destination airport (may differ from the
+    geographic `nearest_airport`; e.g. Verdon Gorge shows MRS, not NCE).
+  - `--interest` flag accepts names (`beaches`, `climbing`, …), aliases, or raw Knowledge-Graph
+    MIDs (`/m/…`).
+  - `--to` flag filters to a destination airport or geographic region (Alps, Northern Europe, …).
+- **`request_cheapest_dates`** — scans a range of months for the cheapest one-way or round-trip
+  departure dates; returns `Vec<CheapDate>` sorted by price.
+- **`request_date_grid`** — full departure × return price matrix from `GetCalendarGrid`;
+  returns `Vec<DateGridEntry>`.  Now runs chunks concurrently (`buffer_unordered(8)`)
+  with per-chunk body-read retry on EOF, reducing round-trip scan time from ~10 min to ~30 s.
+- **Multi-city (open-jaw) search** — `MultiCityConfig::builder()` with per-leg
+  `max_price`, `carry_on`, `checked_bags` filters.
+- **Arrives-next-day detection** — `Itinerary::arrives_next_day()`, `arrival_date()`,
+  `departure_date()` derived from raw date fields.
+- **`max_price` filter** on `Config` and `MultiCityConfig`.
+- **Baggage filter** (`carry_on`, `checked_bags`) on `Config`.
+- **`AirlineFilter`** with `Alliance` variants (OneWorld, SkyTeam, StarAlliance) and
+  `FromStr` parsing (`"LX"`, `"ONEWORLD"`, `"star_alliance"`).
+- **`stopover_min`** field on `Config` — minimum layover duration.
+- **`language` / `country`** on `Config` and `ExploreConfig` — removes hard-coded `en-GB`.
 - **`sort_order`** field on `Config` (`SortOrder` enum: Best, Price, Duration,
   DepartureTime, ArrivalTime).
-- **`stopover_min`** field on `Config` — minimum layover duration complementing
-  the existing `stopover_max`.
-- **Retry logic** (`RetryConfig`) — exponential back-off (base × 2ⁿ, capped)
-  with jitter for 5xx and timeout errors; configurable via
-  `ApiClient::with_retry_config()`.
-- **`gflights` CLI binary** — `search`, `graph`, and `offer` subcommands with
-  `--format table|json` output and full `CommonArgs` (airports, dates, class,
-  stops, currency, locale).
-- **Sync builder setters** `departure_location(Location)` and
-  `destination_location(Location)` on `ConfigBuilder` (for unit tests that
-  cannot call the async city-lookup methods).
-- **Live integration tests** (`tests/live_api.rs`, gated behind
-  `RUN_LIVE_TESTS=1`): locale test (fr-FR), concurrency test (3 parallel
-  tasks), click-token test, invalid-IATA test, shared `OnceCell<ApiClient>`.
-- **Unit tests** — 112 tests total (was 54); parser line coverage ≥ 80 %.
-- **CI** (`.github/workflows/ci.yml`) — build, unit+doc tests, Clippy, Rustfmt,
-  and Rustdoc on Ubuntu and Windows.
-- **`CHANGELOG.md`** and improved `README.md` with features table, quick-start
-  examples, config reference, retry / rate-limiting docs.
+- **Rate-limiter** (governor token bucket, 10 req/s default) with 429 detection flag and
+  `reset_rate_limit()`.  Shared across all clones of an `ApiClient`.
+- **Retry logic** (`RetryConfig`) — exponential back-off for 5xx/timeout; configurable via
+  `ApiClient::with_retry_config()`.  `request_date_grid` also retries body-read errors.
+- **`RateLimitedError`** — downcasting sentinel for HTTP 429.
+- **`Travelers::new()`** — validates ≥1 adult, total ≤9; previously unchecked.
+- **`PlaceType::from(i32)` non-panicking** — unknown discriminants return `Unspecified`
+  with a `tracing::warn!` instead of panicking.
 
-### Changed
+#### CLI (`gflights` binary)
 
-- `FlightRequestOptions`, `GraphRequestOptions`, and `ItineraryRequest::new()`
-  now accept `stopover_min: &StopoverDuration`.
-- `SingleLegStruct::serialize_to_web()` format string extended to position 13
-  for `stopover_min` (inferred; verify with live traffic if needed).
-- `do_request()` now retries on 5xx and timeout rather than propagating the
-  first failure.
-- `tracing-subscriber` moved from `[dev-dependencies]` to `[dependencies]`
-  (required by the `gflights` binary at runtime).
+- `search` subcommand: `--airline`, `--exclude-airline`, `--via`, `--min-layover`,
+  `--max-layover`, `--lower-emissions`, `--sort`, `--format`.
+- `search --show-co2` — CO₂ kg column in table output.
+- `search --detail` — layover airports (`via ZRH (65 min)`) and `+1` next-day marker.
+- `graph` subcommand.
+- `dgrid` subcommand.
+- `offer` subcommand (booking offers + deep links).
+- `cheap` subcommand (cheapest departure dates, `--trip-days N` for round trips).
+- `explore` subcommand with `--interest`, `--to`, `--duration`, `--month`, `--budget`.
+- `mcity` (multi-city) subcommand.
+- Interactive **REPL** with readline history; `--help` works inside the REPL.
+
+#### Python bindings (`gflights-py`)
+
+- Async Python bindings via pyo3 + maturin.
+- `GFlights` class with methods: `search`, `price_graph`, `date_grid`,
+  `multi_city_search`, `explore`, `cheapest_dates`.
+- **`GFlightsError`** — typed exception class; all API errors now raise
+  `GFlightsError` (a `Exception` subclass) instead of `RuntimeError`.
+- Full `.pyi` type stubs for IDE support and mypy compatibility.
+- `CheapDate`, `ExploreResult`, `EmissionsInfo`, `LayoverInfo`, `LegInfo` data classes.
+- `rate_limited` flag and `reset_rate_limit()` on `GFlights`.
+
+#### Tests
+
+- **Wire-protocol tests** (`tests/wire.rs`) — 19 tests feeding captured fixtures through
+  parsers and asserting field values.
+- **Negative / error-input tests** (`tests/negative.rs`) — 39 tests covering bad input
+  validation, malformed response bodies, and error message content.
+- Live integration tests (`tests/live_api.rs`, gated behind `RUN_LIVE_TESTS=1`).
+- Python offline test suite: `test_import.py`, `test_types.py`, `test_errors.py`.
 
 ### Fixed
 
-- `Travelers::new([0, …])` now returns `Err` instead of silently constructing
-  an invalid `Travelers` with 0 adults.
-- `PlaceType::from(i32)` with unknown discriminants now logs a warning and
-  returns `Unspecified` instead of panicking.
+- `Travelers::new([0, …])` returned `Ok` with 0 adults; now returns `Err`.
+- `PlaceType::from(i32)` panicked on undocumented values; now logs warning and
+  returns `Unspecified`.
+- `explore` CLI ARPT column showed geographic nearest airport (NCE) instead of the
+  actual flight destination airport (MRS for Verdon Gorge).
+- REPL `--help` flag triggered `UnknownArgument` error instead of printing help.
+- `_gflights.pyi` had unresolved merge-conflict markers from `feat/multi-city`;
+  `explore()`, `cheapest_dates()`, and `multi_city_search(max_price, …)` signatures
+  were missing.
+- Date-grid chunking looped without moving the window, producing all-identical requests.
 
-[Unreleased]: https://github.com/YOUR_USERNAME/google-flights-rs/compare/HEAD...HEAD
+### Changed
+
+- `request_date_grid` chunks are now dispatched concurrently with `buffer_unordered(8)`.
+- `do_request()` retries 5xx/timeout errors; `request_date_grid_chunk` additionally
+  retries body-read errors (EOF from mid-stream connection closure).
+- CI runs on pull requests only (not on every push to master).
+
+---
+
+## [0.1.0] — 2026-04-01
+
+Initial release.
+
+- Flight search (one-way and return).
+- Price graph (`GetCalendarGraph`).
+- Booking offer resolution.
+- City / airport lookup.
+
+[Unreleased]: https://github.com/nas-/google-flights-rs/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/nas-/google-flights-rs/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/nas-/google-flights-rs/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gflights
 
 [![crates.io](https://img.shields.io/crates/v/gflights)](https://crates.io/crates/gflights)
+[![docs.rs](https://img.shields.io/docsrs/gflights)](https://docs.rs/gflights)
+[![CI](https://github.com/nas-/google-flights-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/nas-/google-flights-rs/actions/workflows/ci.yml)
 
 Unofficial async Rust client for the [Google Flights](https://www.google.com/flights) web API.
 
@@ -74,6 +76,18 @@ gflights dgrid --from LHR --to JFK \
 
 # Booking offers with clickable URLs (OSC 8, supported in most modern terminals)
 gflights offer --from FRA --to SIN --date 2026-10-01
+
+# Explore cheap destinations (Google Flights Explore)
+gflights explore --from LUX --month 9 --duration week --budget 150 --interest climbing
+
+# Find cheapest departure dates (one-way)
+gflights cheap --from LHR --to BCN --date 2026-08-01 --months 3
+
+# Find cheapest round-trip combinations (fixed trip length)
+gflights cheap --from LHR --to BCN --date 2026-08-01 --months 3 --trip-days 7
+
+# Search with emissions column and layover detail
+gflights search --from LUX --to SYD --date 2026-09-01 --show-co2 --detail
 ```
 
 ### Interactive REPL
@@ -105,6 +119,8 @@ gflights> quit
 | `--min-layover <MINS>` | none | Minimum layover in minutes (rounded up to 30 min intervals) |
 | `--max-layover <MINS>` | none | Maximum layover in minutes |
 | `--lower-emissions` | off | Restrict to below-average CO₂ flights |
+| `--show-co2` | off | Add a CO₂ kg column to the table output |
+| `--detail` | off | Show layover airports (`via ZRH (65 min)`) and `+1` for next-day arrivals |
 | `--currency <CURRENCY>` | `euro` | Result currency (e.g. `us-dollar`, `british-pound`) |
 | `--lang <CODE>` | `en` | BCP-47 language subtag |
 | `--country <CODE>` | `GB` | ISO 3166-1 alpha-2 country code |
@@ -242,6 +258,107 @@ Run with:
 ```sh
 cargo run --example multi_city
 ```
+
+---
+
+## Python bindings
+
+The `gflights-py/` directory provides async Python bindings built with [pyo3](https://pyo3.rs) and [maturin](https://www.maturin.rs).
+
+### Install
+
+```sh
+pip install gflights          # when published to PyPI
+# or build from source:
+cd gflights-py && maturin develop
+```
+
+### Quick start
+
+```python
+import asyncio
+import gflights
+
+async def main():
+    client = gflights.GFlights()
+
+    # One-way search
+    flights = await client.search(
+        from_airport="LHR", to_airport="JFK", date="2026-08-01",
+    )
+    for f in flights:
+        print(f.airline, f.duration_minutes, f.price)
+
+    # Price graph — cheapest fare per day over 3 months
+    graph = await client.price_graph(
+        from_airport="LHR", to_airport="JFK", date="2026-08-01", months=3
+    )
+    cheapest = min(graph, key=lambda e: e.price)
+    print(cheapest.date, cheapest.price)
+
+    # Departure × return price grid
+    grid = await client.date_grid(
+        from_airport="LHR", to_airport="JFK",
+        dep_start="2026-08-01", dep_end="2026-08-07",
+        ret_start="2026-08-14", ret_end="2026-08-21",
+    )
+    best = min(grid, key=lambda e: e.price)
+    print(best.dep_date, "→", best.ret_date, best.price)
+
+    # Cheapest departure dates (one-way)
+    dates = await client.cheapest_dates(
+        from_airport="LHR", to_airport="JFK", date="2026-08-01", months=3
+    )
+    for d in dates[:5]:
+        print(d.departure_date, d.price)
+
+    # Cheapest round-trip combinations (7-night stay)
+    rt_dates = await client.cheapest_dates(
+        from_airport="LHR", to_airport="JFK",
+        date="2026-08-01", months=3, trip_duration_days=7
+    )
+    for d in rt_dates[:5]:
+        print(d.departure_date, "→", d.return_date, d.price)
+
+    # Explore cheap destinations
+    dests = await client.explore(
+        from_airport="LUX", month=9, duration="week",
+        max_price=200, interest="beaches",
+    )
+    for d in sorted(dests, key=lambda x: x.price or 9999)[:5]:
+        print(d.name, d.country, d.flight_airport or d.nearest_airport, d.price)
+
+    # Run multiple searches concurrently
+    lhr_jfk, mad_mex = await asyncio.gather(
+        client.search(from_airport="LHR", to_airport="JFK", date="2026-09-01"),
+        client.search(from_airport="MAD", to_airport="MEX", date="2026-09-01"),
+    )
+
+asyncio.run(main())
+```
+
+### Error handling
+
+All API errors raise `gflights.GFlightsError` (a subclass of `Exception`).
+Input validation errors (bad date, unknown currency, etc.) raise `ValueError`.
+
+```python
+try:
+    flights = await client.search(from_airport="LHR", to_airport="JFK", date="2026-08-01")
+except gflights.GFlightsError as e:
+    print(f"API error: {e}")
+except ValueError as e:
+    print(f"Bad input: {e}")
+```
+
+### Rate limiting
+
+The `client.rate_limited` flag is set to `True` when Google returns HTTP 429.
+Call `client.reset_rate_limit()` after a cooling-off period.
+
+### Python type stubs
+
+Full `.pyi` stubs are shipped with the package.  Every method and class is typed and documented, so IDE auto-completion and mypy work out of the box.
 
 ---
 


### PR DESCRIPTION
README:
- Add CI and docs.rs badges.
- Add Python bindings section: install, quick start (all 6 methods), error handling (GFlightsError + ValueError), rate limiting, type stubs.
- Add explore and cheap CLI examples to One-shot mode section.
- Add --show-co2 and --detail to search flag reference table.

CHANGELOG:
- Promote Unreleased block to [0.2.0] dated 2026-06-03.
- Document all features added since 0.1.0: explore, cheapest_dates, date-grid, multi-city, arrives_next_day, filters, rate limiter, retry, CLI flags (--show-co2, --detail, --interest, --to, --via, etc.), Python bindings, GFlightsError, wire/negative tests.
- Document fixes: Travelers validation, PlaceType panic, explore airport column, REPL --help, .pyi conflicts, date-grid chunking.
- Add link anchors for all versions.