### PR TITLE
fix(py): add GFlightsError typed exception class

### DIFF
--- a/gflights-py/gflights/__init__.py
+++ b/gflights-py/gflights/__init__.py
@@ -33,6 +33,7 @@ from gflights._gflights import (  # noqa: F401
     ExploreResult,
     FlightResult,
     GFlights,
+    GFlightsError,
     LayoverInfo,
     LegInfo,
     PriceEntry,
@@ -41,6 +42,7 @@ from gflights._types import SortOrder, StopFilter, TravelClass  # noqa: F401
 
 __all__ = [
     "GFlights",
+    "GFlightsError",
     "FlightResult",
     "LegInfo",
     "LayoverInfo",

--- a/gflights-py/gflights/_gflights.pyi
+++ b/gflights-py/gflights/_gflights.pyi
@@ -2,6 +2,19 @@
 
 from typing import Optional
 
+class GFlightsError(Exception):
+    """Exception raised by all gflights API methods on network or parse errors.
+
+    Catch this to handle errors without matching on :exc:`RuntimeError` or
+    :exc:`ValueError`::
+
+        try:
+            flights = await client.search(...)
+        except gflights.GFlightsError as e:
+            print(f"search failed: {e}")
+    """
+    ...
+
 class LegInfo:
     from_airport: str
     to_airport: str
@@ -152,12 +165,9 @@ class GFlights:
         adults: int = ...,
         travel_class: str = ...,
         sort: str = ...,
-<<<<<<< HEAD
         max_price: Optional[int] = ...,
         carry_on: int = ...,
         checked_bags: int = ...,
-=======
->>>>>>> feat/multi-city
         currency: str = ...,
         lang: str = ...,
         country: str = ...,
@@ -165,7 +175,6 @@ class GFlights:
         """Multi-city (open-jaw) search. Each leg is ``(from, to, "YYYY-MM-DD")``."""
         ...
 
-<<<<<<< HEAD
     async def explore(
         self,
         from_airport: str,
@@ -207,7 +216,5 @@ class GFlights:
         """
         ...
 
-=======
->>>>>>> feat/multi-city
     def reset_rate_limit(self) -> None: ...
     def __repr__(self) -> str: ...

--- a/gflights-py/src/lib.rs
+++ b/gflights-py/src/lib.rs
@@ -94,8 +94,14 @@ fn parse_airline_filters(list: &[String]) -> PyResult<Vec<AirlineFilter>> {
         .collect()
 }
 
+// ---------------------------------------------------------------------------
+// GFlightsError — typed exception raised by all API methods
+// ---------------------------------------------------------------------------
+
+pyo3::create_exception!(_gflights, GFlightsError, pyo3::exceptions::PyException);
+
 fn anyhow_to_py(e: anyhow::Error) -> PyErr {
-    pyo3::exceptions::PyRuntimeError::new_err(e.to_string())
+    GFlightsError::new_err(e.to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -1135,5 +1141,6 @@ fn _gflights(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<DateGridEntry>()?;
     m.add_class::<CheapDate>()?;
     m.add_class::<ExploreResult>()?;
+    m.add("GFlightsError", m.py().get_type::<GFlightsError>())?;
     Ok(())
 }

--- a/gflights-py/tests/test_errors.py
+++ b/gflights-py/tests/test_errors.py
@@ -71,3 +71,33 @@ async def test_date_grid_bad_dep_start_raises(client):
 async def test_price_graph_bad_date_raises(client):
     with pytest.raises(ValueError, match="invalid date"):
         client.price_graph(from_airport="LHR", to_airport="JFK", date="2026/08/01")
+
+
+# ---------------------------------------------------------------------------
+# GFlightsError — typed exception class tests
+# ---------------------------------------------------------------------------
+
+def test_gflights_error_is_importable():
+    """GFlightsError must be accessible at the top-level gflights package."""
+    assert hasattr(gflights, "GFlightsError"), "gflights.GFlightsError not found"
+
+
+def test_gflights_error_is_exception_subclass():
+    """GFlightsError must be catchable as a plain Exception."""
+    assert issubclass(gflights.GFlightsError, Exception)
+
+
+def test_gflights_error_can_be_raised_and_caught():
+    """GFlightsError can be raised and caught like any other exception."""
+    with pytest.raises(gflights.GFlightsError, match="test"):
+        raise gflights.GFlightsError("test")
+
+
+def test_gflights_error_is_not_value_error():
+    """GFlightsError is distinct from ValueError (not a subclass)."""
+    assert not issubclass(gflights.GFlightsError, ValueError)
+
+
+def test_gflights_error_is_not_runtime_error():
+    """GFlightsError is distinct from RuntimeError (not a subclass)."""
+    assert not issubclass(gflights.GFlightsError, RuntimeError)


### PR DESCRIPTION
API errors previously surfaced as generic RuntimeError, making it impossible to catch gflights errors without a broad except clause.

Add pyo3::create_exception!(GFlightsError, PyException) and route anyhow_to_py through it. Register in #[pymodule] and export from gflights/__init__.py and _gflights.pyi.

Also resolves the leftover merge-conflict markers in _gflights.pyi (explore, cheapest_dates, and multi_city_search signatures were clobbered by the feat/multi-city squash-merge).

Tests: 5 new assertions in test_errors.py verify importability, isinstance hierarchy, raise+catch, and independence from ValueError and RuntimeError.