### PR TITLE
feat(cli): add --show-co2 and --detail flags to search output

### DIFF
--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -205,6 +205,8 @@ Commands:
               --min-layover <MINS>       --max-layover <MINS>
               --lower-emissions          (restrict to below-average CO₂ flights)
     Output:   --sort best|price|duration|departure|arrival
+              --show-co2                 (add CO₂ kg column to table)
+              --detail                   (show layover airports; +1 for next-day arrivals)
               --format table|json
     Locale:   --adults <N>  --class economy|premium-economy|business|first
               --currency <NAME>  --lang <BCP47>  --country <ISO2>
@@ -501,6 +503,29 @@ mod tests {
                 assert_eq!(args.airlines.len(), 2);
                 assert_eq!(args.exclude_airlines.len(), 1);
                 assert_eq!(args.connecting_airports, vec!["CDG"]);
+            }
+            other => panic!("expected Search, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn repl_parse_search_detail_and_co2_flags() {
+        let rc = parse(&[
+            "search",
+            "--from",
+            "LUX",
+            "--to",
+            "BCN",
+            "--date",
+            "2026-09-01",
+            "--show-co2",
+            "--detail",
+        ])
+        .expect("search with --show-co2 --detail should parse");
+        match rc.command {
+            Commands::Search(args) => {
+                assert!(args.show_co2);
+                assert!(args.detail);
             }
             other => panic!("expected Search, got {other:?}"),
         }

--- a/src/bin/cli/search.rs
+++ b/src/bin/cli/search.rs
@@ -42,6 +42,14 @@ pub struct SearchArgs {
     /// May be repeated for multiple airports.
     #[arg(long = "via")]
     pub connecting_airports: Vec<String>,
+
+    /// Show a CO₂ emissions column (kg per passenger).
+    #[arg(long = "show-co2")]
+    pub show_co2: bool,
+
+    /// Show detailed info: layover airports and +1 marker for next-day arrivals.
+    #[arg(long)]
+    pub detail: bool,
 }
 
 pub async fn cmd_search(args: SearchArgs, client: &ApiClient) -> Result<()> {
@@ -108,11 +116,20 @@ pub async fn cmd_search(args: SearchArgs, client: &ApiClient) -> Result<()> {
             println!("{}", serde_json::to_string_pretty(&flights)?);
         }
         OutputFormat::Table => {
-            println!(
-                "{:<8}  {:>6}  {:>5}  {:>5}  ROUTE",
-                "AIRLINE", "PRICE", "STOPS", "MINS"
-            );
-            println!("{}", "-".repeat(60));
+            // Build header dynamically depending on flags.
+            if args.show_co2 {
+                println!(
+                    "{:<8}  {:>6}  {:>5}  {:>5}  {:>7}  ROUTE",
+                    "AIRLINE", "PRICE", "STOPS", "MINS", "CO2(kg)"
+                );
+            } else {
+                println!(
+                    "{:<8}  {:>6}  {:>5}  {:>5}  ROUTE",
+                    "AIRLINE", "PRICE", "STOPS", "MINS"
+                );
+            }
+            println!("{}", "-".repeat(if args.show_co2 { 70 } else { 60 }));
+
             for f in &flights {
                 let price = f
                     .itinerary_cost
@@ -132,15 +149,61 @@ pub async fn cmd_search(args: SearchArgs, client: &ApiClient) -> Result<()> {
                     .last()
                     .map(|d| d.destination_airport_code.as_str())
                     .unwrap_or("?");
-                println!(
-                    "{:<8}  {:>6}  {:>5}  {:>5}  {}→{}",
-                    f.itinerary.flight_by,
-                    price,
-                    f.itinerary.stop_count(),
-                    f.itinerary.total_time_minutes,
-                    from,
-                    to,
-                );
+
+                // "+1" marker when the final leg arrives the calendar day after departure.
+                let next_day = if args.detail && f.itinerary.arrives_next_day() {
+                    " +1"
+                } else {
+                    ""
+                };
+
+                let route = format!("{}→{}{}", from, to, next_day);
+
+                if args.show_co2 {
+                    let co2_str = f
+                        .itinerary
+                        .emissions
+                        .as_ref()
+                        .and_then(|e| e.co2_this_flight_g)
+                        .map(|g| format!("{}", g / 1000))
+                        .unwrap_or_else(|| "—".into());
+                    println!(
+                        "{:<8}  {:>6}  {:>5}  {:>5}  {:>7}  {}",
+                        f.itinerary.flight_by,
+                        price,
+                        f.itinerary.stop_count(),
+                        f.itinerary.total_time_minutes,
+                        co2_str,
+                        route,
+                    );
+                } else {
+                    println!(
+                        "{:<8}  {:>6}  {:>5}  {:>5}  {}",
+                        f.itinerary.flight_by,
+                        price,
+                        f.itinerary.stop_count(),
+                        f.itinerary.total_time_minutes,
+                        route,
+                    );
+                }
+
+                // Detail row: layover airports for multi-stop itineraries.
+                if args.detail {
+                    if let Some(conns) = &f.itinerary.connection_info {
+                        if !conns.is_empty() {
+                            let via_parts: Vec<String> = conns
+                                .iter()
+                                .map(|c| {
+                                    format!(
+                                        "{} ({} min)",
+                                        c.arrival_airport, c.connection_time_minutes
+                                    )
+                                })
+                                .collect();
+                            println!("             via {}", via_parts.join(" → "));
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
--show-co2: adds a CO2(kg) column (from Emissions::co2_this_flight_g, grams→kg). Shows — when emissions data is absent.

--detail: appends +1 to the route column when the flight arrives the calendar day after departure (arrives_next_day()); prints a second indented row per multi-stop itinerary showing layover airports and connection times (e.g. "via ZRH (65 min)").

Both flags are opt-in; default table output is unchanged. Also adds a test: repl_parse_search_detail_and_co2_flags.