### PR TITLE
fix(pyi): resolve merge conflict markers left from feat/multi-city

### DIFF
--- a/gflights-py/gflights/_gflights.pyi
+++ b/gflights-py/gflights/_gflights.pyi
@@ -1,4 +1,4 @@
-﻿"""Type stubs for the compiled Rust extension gflights._gflights."""
+"""Type stubs for the compiled Rust extension gflights._gflights."""
 
 from typing import Optional
 
@@ -152,12 +152,9 @@ class GFlights:
         adults: int = ...,
         travel_class: str = ...,
         sort: str = ...,
-<<<<<<< HEAD
         max_price: Optional[int] = ...,
         carry_on: int = ...,
         checked_bags: int = ...,
-=======
->>>>>>> feat/multi-city
         currency: str = ...,
         lang: str = ...,
         country: str = ...,
@@ -165,7 +162,6 @@ class GFlights:
         """Multi-city (open-jaw) search. Each leg is ``(from, to, "YYYY-MM-DD")``."""
         ...
 
-<<<<<<< HEAD
     async def explore(
         self,
         from_airport: str,
@@ -207,7 +203,5 @@ class GFlights:
         """
         ...
 
-=======
->>>>>>> feat/multi-city
     def reset_rate_limit(self) -> None: ...
     def __repr__(self) -> str: ...


### PR DESCRIPTION
explore(), cheapest_dates(), and multi_city_search(max_price, carry_on, checked_bags) were clobbered by an unresolved conflict when feat/multi-city was merged. Restores the correct HEAD-side signatures.