### PR TITLE
chore(ci): add maturin develop step, run all offline Python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get install -y protobuf-compiler
       - uses: astral-sh/setup-uv@v5
-      # uv sync --dev builds the maturin extension automatically; no separate maturin develop needed.
-      - run: cd gflights-py && uv sync --dev && uv run pytest tests/test_import.py -q
+      - run: cd gflights-py && uv sync --dev && uv run maturin develop && uv run pytest tests/test_import.py tests/test_types.py tests/test_errors.py -v


### PR DESCRIPTION
uv sync --dev does not build the Rust extension; maturin develop is required before pytest can import _gflights. Also expand test coverage from test_import.py only to all three offline suites (test_import, test_types, test_errors).