### PR TITLE
feat(config): raise airport cap per side from 4 to 7

### DIFF
--- a/src/requests/config/builder.rs
+++ b/src/requests/config/builder.rs
@@ -9,6 +9,11 @@ use crate::requests::api::ApiClient;
 
 use super::{Config, Currency, TripType};
 
+/// Maximum number of airports Google Flights accepts per origin/destination side.
+/// Exceeding this makes the API silently return zero results, so the builder
+/// rejects the overflow up front.
+const MAX_AIRPORTS_PER_SIDE: usize = 7;
+
 /// Builder for [`Config`].  Obtain one via [`Config::builder()`].
 pub struct ConfigBuilder {
     pub(super) departing_date: Option<NaiveDate>,
@@ -97,12 +102,10 @@ impl ConfigBuilder {
         self
     }
 
-    /// Add an additional departure airport/city (up to 4 total).
+    /// Add an additional departure airport/city (up to 7 total).
     /// Google Flights will search "any of these airports" as the origin.
     pub async fn add_departure(mut self, location: &str, client: &ApiClient) -> Result<Self> {
-        if self.departure.len() >= 4 {
-            return Err(anyhow!("A maximum of 4 departure airports is supported"));
-        }
+        ensure_airport_capacity(self.departure.len(), "departure")?;
         let loc = get_location(location, client).await?;
         self.departure.push(loc);
         Ok(self)
@@ -125,12 +128,10 @@ impl ConfigBuilder {
         self
     }
 
-    /// Add an additional destination airport/city (up to 4 total).
+    /// Add an additional destination airport/city (up to 7 total).
     /// Google Flights will search "any of these airports" as the destination.
     pub async fn add_destination(mut self, location: &str, client: &ApiClient) -> Result<Self> {
-        if self.destination.len() >= 4 {
-            return Err(anyhow!("A maximum of 4 destination airports is supported"));
-        }
+        ensure_airport_capacity(self.destination.len(), "destination")?;
         let loc = get_location(location, client).await?;
         self.destination.push(loc);
         Ok(self)
@@ -359,6 +360,17 @@ async fn get_location(location: &str, client: &ApiClient) -> Result<Location, an
     Ok(departure)
 }
 
+/// Returns an error if a side already holds [`MAX_AIRPORTS_PER_SIDE`] airports,
+/// i.e. adding one more would exceed what Google Flights accepts.
+fn ensure_airport_capacity(current: usize, side: &str) -> Result<()> {
+    if current >= MAX_AIRPORTS_PER_SIDE {
+        return Err(anyhow!(
+            "A maximum of {MAX_AIRPORTS_PER_SIDE} {side} airports is supported"
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -367,6 +379,24 @@ mod tests {
 
     fn future_date(days: i64) -> NaiveDate {
         Utc::now().date_naive() + Duration::days(days)
+    }
+
+    /// The capacity guard allows up to seven airports and rejects the eighth,
+    /// with a message naming the side. Exercises the exact check used by
+    /// `add_departure`/`add_destination` without a network round-trip.
+    #[test]
+    fn airport_capacity_allows_seven_rejects_eighth() {
+        for occupied in 0..MAX_AIRPORTS_PER_SIDE {
+            assert!(
+                ensure_airport_capacity(occupied, "departure").is_ok(),
+                "{occupied} occupied airports should still allow another"
+            );
+        }
+        let err = ensure_airport_capacity(MAX_AIRPORTS_PER_SIDE, "destination")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("maximum of 7"), "got: {err}");
+        assert!(err.contains("destination"), "got: {err}");
     }
 
     /// `build()` returns an error when no departure airport was set.

--- a/src/requests/config/mod.rs
+++ b/src/requests/config/mod.rs
@@ -32,15 +32,15 @@ pub enum TripType {
 
 /// The `Config` struct is used to specify the options for a flight search.
 ///
-/// `departure` and `destination` each hold 1–4 airports.  When multiple
+/// `departure` and `destination` each hold 1–7 airports.  When multiple
 /// airports are supplied Google Flights treats them as "any of these" for
 /// that end of the journey (e.g. all London-area airports as the origin).
 #[derive(Debug, Clone)]
 pub struct Config {
     pub departing_date: NaiveDate,
-    /// One to four departure airports / city identifiers.
+    /// One to seven departure airports / city identifiers.
     pub departure: Vec<Location>,
-    /// One to four destination airports / city identifiers.
+    /// One to seven destination airports / city identifiers.
     pub destination: Vec<Location>,
     pub stop_options: StopOptions,
     pub travel_class: TravelClass,
@@ -429,43 +429,57 @@ mod tests {
     // Multi-airport unit tests
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn builder_accumulates_airports_up_to_four() {
-        let lhr = Location {
-            loc_identifier: "LHR".to_owned(),
-            loc_type: PlaceType::Airport,
-            location_name: None,
-        };
-        let lgw = Location {
-            loc_identifier: "LGW".to_owned(),
-            loc_type: PlaceType::Airport,
-            location_name: None,
-        };
-        let stn = Location {
-            loc_identifier: "STN".to_owned(),
-            loc_type: PlaceType::Airport,
-            location_name: None,
-        };
-        let ltn = Location {
-            loc_identifier: "LTN".to_owned(),
-            loc_type: PlaceType::Airport,
-            location_name: None,
-        };
-        let jfk = Location {
-            loc_identifier: "JFK".to_owned(),
-            loc_type: PlaceType::Airport,
-            location_name: None,
-        };
+    /// Helper: build a list of airport [`Location`]s from IATA codes.
+    fn airports(codes: &[&str]) -> Vec<Location> {
+        codes
+            .iter()
+            .map(|c| Location {
+                loc_identifier: (*c).to_owned(),
+                loc_type: PlaceType::Airport,
+                location_name: None,
+            })
+            .collect()
+    }
 
+    #[test]
+    fn builder_accumulates_airports_up_to_seven() {
+        // Google Flights accepts up to 7 airports per side.
         let config = Config {
             departing_date: future_date(30),
-            departure: vec![lhr, lgw, stn, ltn],
-            destination: vec![jfk],
+            departure: airports(&["LHR", "LGW", "STN", "LTN", "LCY", "SEN", "BHX"]),
+            destination: airports(&["JFK"]),
             trip_type: TripType::OneWay,
             ..Default::default()
         };
-        assert_eq!(config.departure.len(), 4);
+        assert_eq!(config.departure.len(), 7);
         assert_eq!(config.destination.len(), 1);
+    }
+
+    #[test]
+    fn multi_departure_produces_seven_proto_entries() {
+        let codes = ["LHR", "LGW", "STN", "LTN", "LCY", "SEN", "BHX"];
+        let config = Config {
+            departing_date: future_date(30),
+            departure: airports(&codes),
+            destination: airports(&["JFK"]),
+            trip_type: TripType::OneWay,
+            ..Default::default()
+        };
+        let legs: Vec<protos::urls::Leg> = (&config).into();
+        assert_eq!(legs.len(), 1);
+        assert_eq!(
+            legs[0].departure.len(),
+            7,
+            "all seven origin airports should appear as separate proto entries"
+        );
+        let got: Vec<&str> = legs[0]
+            .departure
+            .iter()
+            .map(|l| l.place_name.as_str())
+            .collect();
+        for c in codes {
+            assert!(got.contains(&c), "missing {c} in proto entries");
+        }
     }
 
     #[test]

--- a/src/requests/config/multi_city.rs
+++ b/src/requests/config/multi_city.rs
@@ -50,9 +50,9 @@ impl Default for LegFilters {
 /// A single leg in a multi-city itinerary.
 #[derive(Debug, Clone)]
 pub struct MultiCityLeg {
-    /// One to four origin airports / city identifiers.
+    /// One to seven origin airports / city identifiers.
     pub from: Vec<Location>,
-    /// One to four destination airports / city identifiers.
+    /// One to seven destination airports / city identifiers.
     pub to: Vec<Location>,
     pub date: NaiveDate,
     // Per-leg filters — default to "unrestricted".

--- a/tests/live_api.rs
+++ b/tests/live_api.rs
@@ -216,6 +216,54 @@ fn oneway_search_returns_flights() -> Result<()> {
     })
 }
 
+/// Searching with the maximum of seven origin airports against a single
+/// destination returns flights — exercises the 4→7 airport-cap raise
+/// end-to-end against the live API.
+#[test]
+fn seven_origin_airports_search_returns_flights() -> Result<()> {
+    require_live!();
+    test_rt().block_on(async {
+        let client = live_client();
+
+        let config = Config::builder()
+            .departure("LHR", client)
+            .await?
+            .add_departure("LGW", client)
+            .await?
+            .add_departure("STN", client)
+            .await?
+            .add_departure("LTN", client)
+            .await?
+            .add_departure("MAN", client)
+            .await?
+            .add_departure("BHX", client)
+            .await?
+            .add_departure("EDI", client)
+            .await?
+            .destination("JFK", client)
+            .await?
+            .departing_date(days_from_now(30))
+            .build()?;
+
+        assert_eq!(config.departure.len(), 7, "all seven origins should be set");
+
+        let response = client.request_flights(&config).await?;
+        let flights: Vec<_> = response
+            .responses
+            .iter()
+            .filter_map(|r| r.maybe_get_all_flights())
+            .flatten()
+            .collect();
+
+        assert!(
+            !flights.is_empty(),
+            "expected ≥1 flight for a 7-origin UK→JFK search"
+        );
+
+        Ok(())
+    })
+}
+
 /// Every flight returned has structurally valid fields.
 ///
 /// Specifically:


### PR DESCRIPTION
Google Flights accepts up to 7 airports per origin/destination side; exceeding it silently returns zero results. The builder capped at 4, an artificial limit. Extract the duplicated guard into a shared ensure_airport_capacity helper keyed on MAX_AIRPORTS_PER_SIDE.

Verified live: a 7-origin search returns flights.