### PR TITLE
chore(release): prepare 0.2.0 — versions, abi3 wheels, release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+# Publishes the Rust crate to crates.io and the Python package to PyPI when a
+# `v*` tag is pushed (e.g. `v0.2.0`). The crate is published first so the
+# Python sdist can resolve `gflights` from crates.io. PyPI upload uses Trusted
+# Publishing (OIDC) via the `pypi` environment — no API token stored.
+#
+# Build needs no system protoc: build.rs uses a vendored protoc binary.
+# Wheels are abi3 (one wheel per platform, CPython 3.10+).
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  crate:
+    name: Publish crate to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish -p gflights --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  wheels:
+    name: Wheels (${{ matrix.platform.os }} / ${{ matrix.platform.target }})
+    needs: crate
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { os: ubuntu-latest,  target: x86_64 }
+          - { os: windows-latest, target: x64 }
+          - { os: macos-13,       target: x86_64 }
+          - { os: macos-latest,   target: aarch64 }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build abi3 wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: auto
+          args: --release --out dist -m gflights-py/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform.os }}-${{ matrix.platform.target }}
+          path: dist
+
+  sdist:
+    name: Build sdist
+    needs: crate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist -m gflights-py/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-sdist
+          path: dist
+
+  pypi:
+    name: Publish to PyPI
+    needs: [wheels, sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.2.0] — 2026-06-03
+## [0.2.0] — 2026-06-04
 
 ### Added
 
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with per-chunk body-read retry on EOF, reducing round-trip scan time from ~10 min to ~30 s.
 - **Multi-city (open-jaw) search** — `MultiCityConfig::builder()` with per-leg
   `max_price`, `carry_on`, `checked_bags` filters.
+- **Up to 7 airports per side** — `departure` / `destination` (and each multi-city
+  leg) now accept up to 7 origin/destination airports, matching Google's maximum
+  (previously capped at 4).
 - **Arrives-next-day detection** — `Itinerary::arrives_next_day()`, `arrival_date()`,
   `departure_date()` derived from raw date fields.
 - **`max_price` filter** on `Config` and `MultiCityConfig`.
@@ -68,6 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Python bindings (`gflights-py`)
 
 - Async Python bindings via pyo3 + maturin.
+- Wheels use the CPython **abi3** stable ABI: a single wheel per platform works
+  on CPython 3.10+.
 - `GFlights` class with methods: `search`, `price_graph`, `date_grid`,
   `multi_city_search`, `explore`, `cheapest_dates`.
 - **`GFlightsError`** — typed exception class; all API errors now raise

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "gflights"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Unofficial async Rust client for the Google Flights web API — search flights, price graphs, and booking offers."
 license = "MIT"

--- a/gflights-py/Cargo.toml
+++ b/gflights-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gflights-py"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Python bindings for gflights — unofficial Rust client for Google Flights"
 license = "MIT"
@@ -11,8 +11,10 @@ name = "_gflights"
 crate-type = ["cdylib"]
 
 [dependencies]
-gflights = { path = ".." }
-pyo3 = { version = "0.24", features = ["extension-module"] }
+# `path` is used for local builds; `version` lets the published sdist resolve
+# the crate from crates.io (publish the crate before building the sdist).
+gflights = { version = "0.2.0", path = ".." }
+pyo3 = { version = "0.24", features = ["extension-module", "abi3-py310"] }
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 anyhow = "1"

--- a/gflights-py/pyproject.toml
+++ b/gflights-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "gflights"
-version = "0.1.0"
+version = "0.2.0"
 description = "Unofficial async Python client for Google Flights, powered by a Rust backend"
 license = { text = "MIT" }
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump the crate, the gflights-py crate, and pyproject to 0.2.0. Add a tag-triggered release workflow that publishes the crate to crates.io, then builds abi3 wheels + an sdist and uploads to PyPI via Trusted Publishing. Switch the gflights-py dependency to version+path so the published sdist resolves the crate from crates.io. Enable pyo3 abi3-py310 (one wheel per platform, CPython 3.10+). Record the 4->7 airport cap and abi3 wheels in the changelog.