### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] — 2026-07-10
+
+### Fixed
+
+- **Live requests rejected by the backend** — every search/offer had started
+  returning a `travel.frontend.flights.ErrorResponse`. Diffing our wire request
+  against a real browser capture found four stale/incorrect fields, all now
+  corrected:
+  - `f.sid` is read per-session from the main page (`FdrFJe`) and rewritten onto
+    every endpoint URL instead of a stale hardcoded value.
+  - the rotted experiment-id list at index 7 of the
+    `x-goog-ext-259736195-jspb` header is sent as `null`.
+  - the same-origin XHR headers the browser always sends are now included
+    (`X-Same-Domain`, `Origin`, `Referer`).
+  - shopping requests send the `0,0,0,1` body tail (was the booking-only
+    `1,0,0`).
+- Main-page session cookies are replayed on every request so booking/offer
+  responses include the full reseller list.
+
+### Security
+
+- Bumped `pyo3` / `pyo3-async-runtimes` to `0.29.0` and patched
+  `crossbeam-epoch`, `quinn-proto`, and `anyhow` to clear all open Dependabot /
+  cargo-audit advisories.
+
 ## [0.3.0] — 2026-06-06
 
 ### Added
@@ -213,7 +238,9 @@ Initial release.
 - Booking offer resolution.
 - City / airport lookup.
 
-[Unreleased]: https://github.com/nas-/google-flights-rs/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/nas-/google-flights-rs/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/nas-/google-flights-rs/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/nas-/google-flights-rs/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/nas-/google-flights-rs/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/nas-/google-flights-rs/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/nas-/google-flights-rs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "gflights"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "gflights-py"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "gflights"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Unofficial async Rust client for the Google Flights web API — search flights, price graphs, and booking offers."
 license = "MIT"

--- a/gflights-py/Cargo.toml
+++ b/gflights-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gflights-py"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Python bindings for gflights — unofficial Rust client for Google Flights"
 license = "MIT"
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # `path` is used for local builds; `version` lets the published sdist resolve
 # the crate from crates.io (publish the crate before building the sdist).
-gflights = { version = "0.3.0", path = ".." }
+gflights = { version = "0.3.1", path = ".." }
 pyo3 = { version = "=0.29.0", features = ["extension-module", "abi3-py310"] }
 pyo3-async-runtimes = { version = "=0.29.0", features = ["tokio-runtime"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/gflights-py/pyproject.toml
+++ b/gflights-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "gflights"
-version = "0.3.0"
+version = "0.3.1"
 description = "Unofficial async Python client for Google Flights, powered by a Rust backend"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/parsers/common/location.rs
+++ b/src/parsers/common/location.rs
@@ -19,10 +19,10 @@ impl SerializeToWeb for Location {
         // Airports are encoded as type 0 in the request body regardless of the
         // PlaceType discriminant; all other location types use their discriminant.
         match self.loc_type {
-            PlaceType::Airport => Ok(format!(r#"[\"{}\",{}]"#, &self.loc_identifier, 0_i32)),
+            PlaceType::Airport => Ok(format!(r#"[\"{}\",{}]"#, self.loc_identifier, 0_i32)),
             _ => Ok(format!(
                 r#"[\"{}\",{}]"#,
-                &self.loc_identifier, self.loc_type as i32
+                self.loc_identifier, self.loc_type as i32
             )),
         }
     }

--- a/src/parsers/request/city_request.rs
+++ b/src/parsers/request/city_request.rs
@@ -25,7 +25,7 @@ impl TryFrom<&CityRequestOptions> for RequestBody {
 
         let body = format!(
             r#"f.req=[[["H028ib","[\"{0}\",[1,2,3,5,4],null,[1,1,1],1]",null,"generic"]]]&at=AAuQa1qqZgn5F209lkOLZp20vq5d:{1}&"#,
-            &options.city, epoch_now
+            options.city, epoch_now
         );
 
         let url = format!("{BATCHEXECUTE}?rpcids=H028ib&source-path=/travel/flights&f.sid=-2414068248310847860&bl={}&hl=en-GB&soc-app=162&soc-platform=1&soc-device=1&_reqid=581503&rt=c",options.frontend_version);

--- a/src/parsers/request/flight_request.rs
+++ b/src/parsers/request/flight_request.rs
@@ -1,4 +1,4 @@
-﻿use std::{
+use std::{
     time::{SystemTime, UNIX_EPOCH},
     vec,
 };
@@ -273,15 +273,15 @@ impl SerializeToWeb for SingleLegStruct<'_> {
 
         Ok(format!(
             r#"[{0},{1},{2},{3},{4},{5},\"{6}\",{7},{8},{9},null,{10},{11},{12},{13}]"#,
-            &self.departure.serialize_to_web()?,    // [0]
-            &self.arrival.serialize_to_web()?,      // [1]
-            &self.times.serialize_to_web()?,        // [2]
-            &self.stop_options.serialize_to_web()?, // [3]
+            self.departure.serialize_to_web()?,    // [0]
+            self.arrival.serialize_to_web()?,      // [1]
+            self.times.serialize_to_web()?,        // [2]
+            self.stop_options.serialize_to_web()?, // [3]
             serialize_airline_filters(self.airlines_include), // [4]
             serialize_airline_filters(self.airlines_exclude), // [5]
-            self.date,                              // [6]
-            self.duration_max.serialize_to_web()?,  // [7]
-            chosen_itinerary,                       // [8]
+            self.date,                             // [6]
+            self.duration_max.serialize_to_web()?, // [7]
+            chosen_itinerary,                      // [8]
             serialize_airport_list(self.connecting_airports), // [9]
             // [10] hardcoded null (in format string above)
             self.stopover_min.serialize_to_web()?, // [11] ← FIXED (was [13])
@@ -385,11 +385,11 @@ impl SerializeToWeb for ItineraryRequest<'_> {
             //   [13] legs
             r#"[null,null,{0},null,[],{1},{2},{3},null,null,{4},null,null,{5},null,null,null,1{6}]"#,
             self.sort_order as i32,
-            &self.travel_class.serialize_to_web()?,
-            &self.travelers.serialize_to_web()?,
+            self.travel_class.serialize_to_web()?,
+            self.travelers.serialize_to_web()?,
             serialize_price_filter(self.max_price),
             serialize_baggage(self.baggage),
-            &self.legs.serialize_to_web()?,
+            self.legs.serialize_to_web()?,
             graph
         ))
     }
@@ -423,7 +423,7 @@ impl SerializeToWeb for CompleteFlightRequest<'_> {
         Ok(format!(
             r#"f.req=[null,"[{},{},{}]"]&at=AAuQa1qiXfSThbBOCdcDUAVTopoc:{}&"#,
             departure_token,
-            &self.itinerary.serialize_to_web()?,
+            self.itinerary.serialize_to_web()?,
             end_part,
             epoch_now
         ))

--- a/src/parsers/request/flight_request.rs
+++ b/src/parsers/request/flight_request.rs
@@ -68,6 +68,28 @@ impl TryFrom<&FlightRequestOptions<'_>> for RequestBody {
         let arrival = vec![options.arriving_city.iter().collect::<Vec<_>>()];
         let itinerary_going = options.fixed_flights.maybe_get_nth_flight_info(0_usize);
         let itinerary_return = options.fixed_flights.maybe_get_nth_flight_info(1_usize);
+
+        // When the itinerary is fully pinned (booking / offer request), the
+        // per-leg search filters must be cleared. The browser sends `null` for
+        // them on `GetBookingResults` because the exact flight is already
+        // specified. Leaving the airline include/exclude filter in place makes
+        // Google return only the airline-direct offer and suppresses the OTA
+        // reseller list. Mirror that: drop airline/connecting/emissions filters
+        // for booking requests (search requests keep them).
+        let is_booking = options.fixed_flights.is_full();
+        let empty_airlines: &[AirlineFilter] = &[];
+        let empty_airports: &[String] = &[];
+        let (inc, exc, conn, low_co2) = if is_booking {
+            (empty_airlines, empty_airlines, empty_airports, false)
+        } else {
+            (
+                options.airlines_include,
+                options.airlines_exclude,
+                options.connecting_airports,
+                options.lower_emissions,
+            )
+        };
+
         let leg1 = SingleLegStruct {
             departure: departure.clone(),
             arrival: arrival.clone(),
@@ -78,10 +100,10 @@ impl TryFrom<&FlightRequestOptions<'_>> for RequestBody {
             stopover_min: options.stopover_min,
             duration_max: options.duration_max,
             chosen_itinerary: itinerary_going.as_ref(),
-            airlines_include: options.airlines_include,
-            airlines_exclude: options.airlines_exclude,
-            connecting_airports: options.connecting_airports,
-            lower_emissions: options.lower_emissions,
+            airlines_include: inc,
+            airlines_exclude: exc,
+            connecting_airports: conn,
+            lower_emissions: low_co2,
         };
         let leg2 = options.date_return.map(|date_return| SingleLegStruct {
             departure: arrival,
@@ -93,18 +115,16 @@ impl TryFrom<&FlightRequestOptions<'_>> for RequestBody {
             stopover_min: options.stopover_min,
             duration_max: options.duration_max,
             chosen_itinerary: itinerary_return.as_ref(),
-            airlines_include: options.airlines_include,
-            airlines_exclude: options.airlines_exclude,
-            connecting_airports: options.connecting_airports,
-            lower_emissions: options.lower_emissions,
+            airlines_include: inc,
+            airlines_exclude: exc,
+            connecting_airports: conn,
+            lower_emissions: low_co2,
         });
         let legs: Vec<SingleLegStruct<'_>> = if let Some(leg_2) = leg2 {
             vec![leg1, leg_2]
         } else {
             vec![leg1]
         };
-
-        let is_booking = options.fixed_flights.is_full();
 
         let itinerary = ItineraryRequest {
             legs,
@@ -130,6 +150,8 @@ impl TryFrom<&FlightRequestOptions<'_>> for RequestBody {
         } else {
             FLIGHT_REQUEST
         };
+        // The `f.sid` placeholder here is overwritten per-session in
+        // `ApiClient::do_request` (a stale value is rejected by the backend).
         let url = format!(
             "{endpoint}?f.sid=6921237406276106431&bl={}&hl={}-{}&soc-app=162&soc-platform=1&soc-device=1&_reqid=4150414&rt=c",
             options.frontend_version,
@@ -390,9 +412,13 @@ impl SerializeToWeb for CompleteFlightRequest<'_> {
             None => "[]".to_string(),
         };
 
-        // Booking requests (GetBookingResults) use `null,0` as the body tail —
-        // matching what the browser sends.  Regular shopping requests use `1,0,0`.
-        let end_part = if self.is_booking { "null,0" } else { "1,0,0" };
+        // Body tail, matching the live browser wire format exactly:
+        //   * GetBookingResults  -> `null,0`
+        //   * GetShoppingResults -> `0,0,0,1` (both the plain search and the
+        //     token-bearing "outbound selected" step use this)
+        // The previous `1,0,0` is rejected by the backend with an
+        // `ErrorResponse`, so search/offer must send `0,0,0,1`.
+        let end_part = if self.is_booking { "null,0" } else { "0,0,0,1" };
 
         Ok(format!(
             r#"f.req=[null,"[{},{},{}]"]&at=AAuQa1qiXfSThbBOCdcDUAVTopoc:{}&"#,
@@ -585,7 +611,7 @@ mod tests {
         };
 
         let req: RequestBody = (&search_settings).try_into()?;
-        let expected = "f.req=%5Bnull%2C%22%5B%5B%5D%2C%5Bnull%2Cnull%2C1%2Cnull%2C%5B%5D%2C1%2C%5B1%2C0%2C0%2C0%5D%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5B%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-02-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%5D%2Cnull%2Cnull%2Cnull%2C1%5D%2C1%2C0%2C0%5D%22%5D&";
+        let expected = "f.req=%5Bnull%2C%22%5B%5B%5D%2C%5Bnull%2Cnull%2C1%2Cnull%2C%5B%5D%2C1%2C%5B1%2C0%2C0%2C0%5D%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5B%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-02-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%5D%2Cnull%2Cnull%2Cnull%2C1%5D%2C0%2C0%2C0%2C1%5D%22%5D&";
         assert!(req.body.starts_with(expected));
 
         assert!(req.url.contains(&frontend_version));
@@ -637,7 +663,7 @@ mod tests {
         };
 
         let req: RequestBody = (&search_settings).try_into()?;
-        let expected = "f.req=%5Bnull%2C%22%5B%5B%5D%2C%5Bnull%2Cnull%2C1%2Cnull%2C%5B%5D%2C1%2C%5B1%2C0%2C0%2C0%5D%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5B%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-02-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%2C%5B%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-03-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%5D%2Cnull%2Cnull%2Cnull%2C1%5D%2C1%2C0%2C0%5D%22%5D";
+        let expected = "f.req=%5Bnull%2C%22%5B%5B%5D%2C%5Bnull%2Cnull%2C1%2Cnull%2C%5B%5D%2C1%2C%5B1%2C0%2C0%2C0%5D%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5B%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-02-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%2C%5B%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-03-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%5D%2Cnull%2Cnull%2Cnull%2C1%5D%2C0%2C0%2C0%2C1%5D%22%5D";
         assert!(req.body.starts_with(expected));
         Ok(())
     }
@@ -878,7 +904,7 @@ mod tests {
     fn test_complete_flight_request() -> Result<()> {
         let travelers = Travelers::new([1, 0, 0, 0].to_vec())?;
 
-        let expected_two_legs = r#"f.req=[null,"[[],[null,null,1,null,[],4,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"CDG\",0]]],null,0,null,null,\"2022-10-20\",null,null,null,null,null,null,null,3],[[[[\"CDG\",0]]],[[[\"MXP\",0]]],null,0,null,null,\"2022-10-30\",null,null,null,null,null,null,null,3]],null,null,null,1],1,0,0]"]&at=AAuQa1qiXfSThbBOCdcDUAVTopoc:"#;
+        let expected_two_legs = r#"f.req=[null,"[[],[null,null,1,null,[],4,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"CDG\",0]]],null,0,null,null,\"2022-10-20\",null,null,null,null,null,null,null,3],[[[[\"CDG\",0]]],[[[\"MXP\",0]]],null,0,null,null,\"2022-10-30\",null,null,null,null,null,null,null,3]],null,null,null,1],0,0,0,1]"]&at=AAuQa1qiXfSThbBOCdcDUAVTopoc:"#;
 
         let departure = Location {
             loc_identifier: "MXP".to_owned(),

--- a/src/requests/api.rs
+++ b/src/requests/api.rs
@@ -24,7 +24,7 @@ use parsers::flight_request::{FlightRequestOptions, MultiCityRequestOptions};
 use parsers::flight_response::{create_raw_response_vec, FlightResponseContainer};
 use parsers::offer_response::{self, OfferRawResponseContainer};
 use regex::Regex;
-use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::{Client, Response, StatusCode};
 use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -94,6 +94,10 @@ pub struct ApiClient {
     pub rate_limiter: Arc<DefaultDirectRateLimiter>,
     pub client: Arc<Client>,
     frontend_version: String,
+    /// Per-session `f.sid` extracted from the main page (`FdrFJe`). Sent as the
+    /// `f.sid` query param on every API request. A stale hardcoded value is
+    /// rejected by the backend on some locales, so it must track the session.
+    f_sid: String,
     /// Set to `true` the first time any request on this client (or any clone)
     /// receives HTTP 429.  While `true`, every call to `do_request` returns
     /// [`RateLimitedError`] immediately without touching the network.
@@ -110,6 +114,10 @@ pub struct ApiClient {
     language: String,
     /// ISO 3166-1 alpha-2 country code applied to every request, e.g. `"GB"`.
     country: String,
+    /// `name=value; …` Cookie header built from the main-page `Set-Cookie`s,
+    /// replayed on every API request so the session matches the one the page
+    /// was issued for. `None` if the page set no cookies.
+    session_cookies: Option<Arc<str>>,
 }
 
 impl ApiClient {
@@ -161,19 +169,27 @@ impl ApiClient {
         let user_agent = pick_user_agent().to_string();
         tracing::debug!(%user_agent, proxy = ?proxy, "constructing client");
         let client = build_reqwest_client(proxy.as_deref())?;
-        let frontend_version = get_frontend_version(&user_agent, &client).await;
+        let page = fetch_main_page(&user_agent, &client).await;
+        let frontend_version = page.as_ref().and_then(|(h, _)| extract_frontend_version(h));
+        let f_sid = page.as_ref().and_then(|(h, _)| extract_f_sid(h));
+        let session_cookies = match page {
+            Some((_, c)) => (!c.is_empty()).then(|| Arc::from(c)),
+            None => None,
+        };
 
         Ok(Self {
             rate_limiter,
             client: Arc::new(client),
             frontend_version: frontend_version
                 .unwrap_or("boq_travel-frontend-flights-ui_20260527.01_p0".into()),
+            f_sid: f_sid.unwrap_or_else(|| "-1".into()),
             rate_limited: Arc::new(AtomicBool::new(false)),
             retry_config: RetryConfig::default(),
             user_agent,
             currency: Currency::default(),
             language: "en".to_string(),
             country: "GB".to_string(),
+            session_cookies,
         })
     }
 
@@ -965,9 +981,23 @@ impl ApiClient {
             return Err(anyhow::Error::new(RateLimitedError));
         }
 
-        let req_payload = options.to_request_body()?;
+        let mut req_payload = options.to_request_body()?;
+        // Force the per-session `f.sid` onto every endpoint URL. The request
+        // builders embed a placeholder; a stale hardcoded value is rejected by
+        // the backend with an `ErrorResponse` on some locales, so rewrite it to
+        // the value extracted from this session's main page.
+        req_payload.url = replace_f_sid(&req_payload.url, &self.f_sid);
         tracing::debug!(user_agent = %self.user_agent, "outgoing request User-Agent");
-        let headers = get_headers(currency, language, country, &self.user_agent)?;
+        let mut headers = get_headers(currency, language, country, &self.user_agent)?;
+
+        // Replay the session cookies from the main-page fetch (no cookie jar is
+        // used — a jar traps the page fetch on the consent wall — so cookies are
+        // attached manually here).
+        if let Some(cookies) = self.session_cookies.as_deref() {
+            if let Ok(hv) = HeaderValue::from_str(cookies) {
+                headers.insert(reqwest::header::COOKIE, hv);
+            }
+        }
 
         let decoded_body = percent_encoding::percent_decode_str(&req_payload.body)
             .decode_utf8_lossy()
@@ -1098,15 +1128,26 @@ fn pick_user_agent() -> &'static str {
 }
 
 /// Static base headers shared by all requests, with the given User-Agent.
-///
-/// Note: `x-goog-batchexecute-bgr` is intentionally omitted — its value is
-/// difficult to reverse-engineer and its absence only slightly reduces result
-/// accuracy.
 fn base_headers(user_agent: &str) -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(
         reqwest::header::ACCEPT_LANGUAGE,
         HeaderValue::from_static("en-US,en;q=0.9"),
+    );
+    // The browser sends these on every same-origin batchexecute XHR. Without
+    // `X-Same-Domain` Google validates the request more strictly and can reject
+    // it with an `ErrorResponse` (observed live).
+    headers.insert(
+        HeaderName::from_static("x-same-domain"),
+        HeaderValue::from_static("1"),
+    );
+    headers.insert(
+        reqwest::header::ORIGIN,
+        HeaderValue::from_static("https://www.google.com"),
+    );
+    headers.insert(
+        reqwest::header::REFERER,
+        HeaderValue::from_static("https://www.google.com/travel/flights"),
     );
     headers.insert(
         reqwest::header::CONTENT_TYPE,
@@ -1144,8 +1185,11 @@ fn get_headers(
     let mut headers = base_headers(user_agent);
     if let Some(currency) = currency {
         let country_upper = country.to_uppercase();
+        // NB: index 7 (the experiment-id list) is sent as `null`. Hardcoded
+        // experiment ids rot — once Google retires them the backend rejects the
+        // request with an `ErrorResponse`. The browser sends `null` here too.
         let currency_header = format!(
-            r#"["{language}-{country_upper}","{country_upper}","{}",1,null,[-120],null,[[72534415,72446893,97456553,72399613]],1,[]]"#,
+            r#"["{language}-{country_upper}","{country_upper}","{}",1,null,[-120],null,null,1,[]]"#,
             currency
         );
         let header_value = reqwest::header::HeaderValue::from_str(&currency_header)
@@ -1163,6 +1207,12 @@ fn get_headers(
 /// `proxy` accepts `http://`, `https://`, and `socks5://` URLs. Returns an
 /// error if the proxy URL is invalid or the client cannot be built.
 fn build_reqwest_client(proxy: Option<&str>) -> Result<Client> {
+    // NOTE: do NOT enable a cookie store / `cookie_provider` here. Counter-
+    // intuitively, enabling one makes the main-page GET stick on the EU
+    // consent.google.com wall (the stored consent.google.com Set-Cookie keeps
+    // the redirect on the consent page); with no jar, reqwest's redirect bounces
+    // straight through to the real flights page that carries `WIZ_global_data`.
+    // The session cookies are therefore taken from this same cookieless fetch.
     let mut builder = Client::builder();
     if let Some(url) = proxy {
         builder = builder.proxy(
@@ -1174,15 +1224,30 @@ fn build_reqwest_client(proxy: Option<&str>) -> Result<Client> {
         .map_err(|e| anyhow::anyhow!("failed to build HTTP client: {e}"))
 }
 
-/// Retrieves the frontend version from the Google Flights website, reusing the
-/// supplied client so any configured proxy applies here too.
-async fn get_frontend_version(user_agent: &str, client: &Client) -> Option<String> {
+/// Fetches the Google Flights main page HTML, reusing the supplied client so
+/// any configured proxy applies here too. The HTML is used to extract the
+/// frontend version and the per-session `f.sid`.
+/// Returns `(html, cookie_header)` — the page HTML plus a `name=value; …`
+/// Cookie string built from the response's `Set-Cookie` headers, so the API
+/// requests can replay the same session cookies the page handed us (the
+/// browser sends these on `GetBookingResults`; without them Google returns the
+/// minimal single-vendor offer list).
+async fn fetch_main_page(user_agent: &str, client: &Client) -> Option<(String, String)> {
     let headers = base_headers(user_agent); // no currency header needed for the version fetch
     let url = FLIGHTS_MAIN_PAGE.to_string();
     let res = client.get(&url).headers(headers).send().await.ok()?;
 
     let status = res.status();
     let final_url = res.url().to_string();
+    // Collect Set-Cookie name=value pairs before consuming the body.
+    let cookie_header = res
+        .headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .filter_map(|c| c.split(';').next()) // name=value
+        .collect::<Vec<_>>()
+        .join("; ");
     // Only warn when the base path changes (different host or path).
     // Ignore minor redirects that only add/change query parameters.
     fn base_url(u: &str) -> &str {
@@ -1199,8 +1264,12 @@ async fn get_frontend_version(user_agent: &str, client: &Client) -> Option<Strin
         tracing::debug!(url = %final_url, status = %status, "main page response");
     }
 
-    let response_body = res.text().await.ok()?;
+    let html = res.text().await.ok()?;
+    Some((html, cookie_header))
+}
 
+/// Extracts the frontend version string from the main-page HTML.
+fn extract_frontend_version(response_body: &str) -> Option<String> {
     // Matches both:
     //   boq_travel-frontend-ui_20260527.01_p0  (old)
     //   boq_travel-frontend-flights-ui_20260527.01_p0  (new)
@@ -1215,7 +1284,7 @@ async fn get_frontend_version(user_agent: &str, client: &Client) -> Option<Strin
     };
 
     let result = regex
-        .captures_iter(&response_body)
+        .captures_iter(response_body)
         .map(|f| f.extract::<2>())
         .next();
 
@@ -1230,9 +1299,63 @@ async fn get_frontend_version(user_agent: &str, client: &Client) -> Option<Strin
     Some(result?.0.to_string())
 }
 
+/// Extracts the per-session `f.sid` from the main page (the `FdrFJe` field in
+/// `WIZ_global_data`). Google validates this against the session; a stale
+/// hardcoded value is rejected with an `ErrorResponse` on some locales, so the
+/// live request must echo the page's own value (as the browser does).
+fn extract_f_sid(html: &str) -> Option<String> {
+    let regex = Regex::new(r#"FdrFJe["\]:,]+(-?\d{6,})"#).ok()?;
+    let sid = regex.captures(html)?.get(1)?.as_str().to_string();
+    tracing::debug!(f_sid = %sid, "f.sid extracted");
+    Some(sid)
+}
+
+/// Replaces the value of the `f.sid` query parameter in `url` with `f_sid`,
+/// leaving the rest of the URL untouched. If the URL has no `f.sid` param it is
+/// returned unchanged.
+fn replace_f_sid(url: &str, f_sid: &str) -> String {
+    let Some(start) = url.find("f.sid=") else {
+        return url.to_string();
+    };
+    let value_start = start + "f.sid=".len();
+    let value_end = url[value_start..]
+        .find('&')
+        .map(|i| value_start + i)
+        .unwrap_or(url.len());
+    format!("{}{}{}", &url[..value_start], f_sid, &url[value_end..])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extract_f_sid_reads_fdrfje() {
+        let html = r#"...,"FdrFJe":"-5078133052890781250",..."#;
+        assert_eq!(extract_f_sid(html).as_deref(), Some("-5078133052890781250"));
+    }
+
+    #[test]
+    fn replace_f_sid_rewrites_middle_param() {
+        let url = "https://x/y?f.sid=123&bl=v&hl=en-GB";
+        assert_eq!(
+            replace_f_sid(url, "-99"),
+            "https://x/y?f.sid=-99&bl=v&hl=en-GB"
+        );
+    }
+
+    #[test]
+    fn replace_f_sid_rewrites_trailing_param() {
+        assert_eq!(
+            replace_f_sid("https://x/y?a=1&f.sid=123", "-99"),
+            "https://x/y?a=1&f.sid=-99"
+        );
+    }
+
+    #[test]
+    fn replace_f_sid_noop_without_param() {
+        assert_eq!(replace_f_sid("https://x/y?a=1", "-99"), "https://x/y?a=1");
+    }
 
     /// Build a minimal ApiClient without hitting the network (no frontend-version fetch).
     fn make_client() -> ApiClient {
@@ -1241,12 +1364,14 @@ mod tests {
             rate_limiter: Arc::new(DefaultDirectRateLimiter::direct(quota)),
             client: Arc::new(Client::new()),
             frontend_version: "test".into(),
+            f_sid: "-1".into(),
             rate_limited: Arc::new(AtomicBool::new(false)),
             retry_config: RetryConfig::default(),
             user_agent: pick_user_agent().to_string(),
             currency: Currency::default(),
             language: "en".to_string(),
             country: "GB".to_string(),
+            session_cookies: None,
         }
     }
 


### PR DESCRIPTION
Patch release — no public API changes.

## Fixes (the important one)

Restores live search/offer, which had begun failing with a backend
`travel.frontend.flights.ErrorResponse` on every request. Root causes, found by
diffing our wire request against a real browser capture:

- **`f.sid`** read per-session from the main page (`FdrFJe`) and rewritten onto
  every endpoint URL (the hardcoded value had gone stale and is rejected on some
  locales)
- **jspb header** index-7 experiment-id list sent as `null` (the hardcoded list
  rotted)
- **same-origin headers** `X-Same-Domain` / `Origin` / `Referer` now sent
- **body tail** `0,0,0,1` for shopping requests (was the booking-only `1,0,0`)
- main-page **session cookies** replayed so offer/booking return the full
  reseller list

## Security (already on master via #75, restated for the release notes)

pyo3 / pyo3-async-runtimes `0.29.0`; crossbeam-epoch, quinn-proto, anyhow patched.

## Verification

- `cargo clippy --all-targets -D warnings`, `cargo fmt --check`, `cargo audit`: clean
- Rust lib/bin/doc: 216 / 37 / 11
- **Rust live** (`live_api`): 27 / 27
- Python offline: 39; **Python live**: 19 / 19
- `cargo publish --dry-run`: clean
