### PR TITLE
Fix Google Flights request wire serialization

### DIFF
--- a/src/parsers/common/types.rs
+++ b/src/parsers/common/types.rs
@@ -78,32 +78,35 @@ impl From<i32> for TravelClass {
 }
 
 /// Sort order for flight search results.
-#[derive(Debug, Deserialize, Serialize, Clone, Copy, ValueEnum, Default)]
+///
+/// Discriminants follow Google Flights' sort dropdown — best, price,
+/// departure time, arrival time, duration — the same values the web UI
+/// sends at position 2 of the outer request array.
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
 pub enum SortOrder {
     /// Google's default: best combination of price, duration, and convenience.
     #[default]
     Best = 1,
     /// Sort by total price, cheapest first.
     Price = 2,
-    /// Sort by total journey duration, shortest first.
-    Duration = 3,
     /// Sort by departure time, earliest first.
-    DepartureTime = 4,
+    DepartureTime = 3,
     /// Sort by arrival time, earliest first.
-    ArrivalTime = 5,
+    ArrivalTime = 4,
+    /// Sort by total journey duration, shortest first.
+    Duration = 5,
 }
 
 impl SortOrder {
     /// Returns the sort discriminant to send to the Google Flights backend.
     ///
-    /// `DepartureTime` (4) and `ArrivalTime` (5) are not recognised as valid
-    /// sort modes by the server and cause it to return an empty response.
-    /// Fall back to `Best` for those two and handle the ordering client-side.
+    /// All discriminants are accepted server-side now that they match the
+    /// web UI's values: departure time 3, arrival time 4, duration 5.
+    /// Previously duration, departure and arrival were shifted by one, which
+    /// made the server reject the last two. Kept as a hook in case a future
+    /// mode needs a client-side fallback again.
     pub fn server_sort(self) -> SortOrder {
-        match self {
-            SortOrder::DepartureTime | SortOrder::ArrivalTime => SortOrder::Best,
-            other => other,
-        }
+        self
     }
 }
 
@@ -149,9 +152,9 @@ mod tests {
     fn sort_order_discriminant_values() {
         assert_eq!(SortOrder::Best as i32, 1);
         assert_eq!(SortOrder::Price as i32, 2);
-        assert_eq!(SortOrder::Duration as i32, 3);
-        assert_eq!(SortOrder::DepartureTime as i32, 4);
-        assert_eq!(SortOrder::ArrivalTime as i32, 5);
+        assert_eq!(SortOrder::DepartureTime as i32, 3);
+        assert_eq!(SortOrder::ArrivalTime as i32, 4);
+        assert_eq!(SortOrder::Duration as i32, 5);
     }
 
     #[test]
@@ -160,25 +163,16 @@ mod tests {
     }
 
     #[test]
-    fn sort_order_server_sort_passthrough_for_best_price_duration() {
-        assert!(matches!(SortOrder::Best.server_sort(), SortOrder::Best));
-        assert!(matches!(SortOrder::Price.server_sort(), SortOrder::Price));
-        assert!(matches!(
-            SortOrder::Duration.server_sort(),
-            SortOrder::Duration
-        ));
-    }
-
-    #[test]
-    fn sort_order_server_sort_falls_back_to_best_for_time_based() {
-        assert!(matches!(
-            SortOrder::DepartureTime.server_sort(),
-            SortOrder::Best
-        ));
-        assert!(matches!(
-            SortOrder::ArrivalTime.server_sort(),
-            SortOrder::Best
-        ));
+    fn sort_order_server_sort_is_passthrough_for_all_modes() {
+        for mode in [
+            SortOrder::Best,
+            SortOrder::Price,
+            SortOrder::DepartureTime,
+            SortOrder::ArrivalTime,
+            SortOrder::Duration,
+        ] {
+            assert_eq!(mode.server_sort(), mode);
+        }
     }
 
     #[test]

--- a/src/parsers/request/calendar_graph_request.rs
+++ b/src/parsers/request/calendar_graph_request.rs
@@ -4,7 +4,7 @@ use chrono::NaiveDate;
 use percent_encoding::utf8_percent_encode;
 
 use crate::parsers::common::{
-    FlightTimes, Location, RequestBody, SerializeToWeb, SortOrder, StopOptions, StopoverDuration,
+    FlightTimes, Location, RequestBody, SerializeToWeb, StopOptions, StopoverDuration,
     ToRequestBody, TotalDuration, TravelClass, Travelers, CHARACTERS_TO_ENCODE,
 };
 use crate::parsers::constants::CALENDAR_GRAPH;
@@ -32,8 +32,6 @@ pub struct GraphRequestOptions<'a> {
     pub language: &'a str,
     /// ISO 3166-1 alpha-2 country code (upper-case), e.g. `"GB"`.
     pub country: &'a str,
-    /// Result sort order sent to Google Flights.
-    pub sort_order: &'a SortOrder,
 }
 
 impl ToRequestBody for GraphRequestOptions<'_> {
@@ -62,7 +60,6 @@ impl TryFrom<&GraphRequestOptions<'_>> for RequestBody {
             options.stopover_min,
             options.duration_max,
             true,
-            *options.sort_order,
             None,
             None,
         );
@@ -166,11 +163,10 @@ mod tests {
             frontend_version: &frontend_version,
             language: "en",
             country: "GB",
-            sort_order: &SortOrder::Best,
         };
 
         let req: RequestBody = (&search_settings).try_into()?;
-        let expected = "f.req=%5Bnull%2C%22%5Bnull%2C%5Bnull%2Cnull%2C1%2Cnull%2C%5B%5D%2C1%2C%5B1%2C0%2C0%2C0%5D%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5B%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-02-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%5D%2Cnull%2Cnull%2Cnull%2C1%2C1%5D%2C%5B%5C%222024-02-02%5C%22%2C%5C%222024-05-02%5C%22%5D%5D%22%5D&";
+        let expected = "f.req=%5Bnull%2C%22%5Bnull%2C%5Bnull%2Cnull%2C2%2Cnull%2C%5B%5D%2C1%2C%5B1%2C0%2C0%2C0%5D%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5B%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-02-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%5D%2Cnull%2Cnull%2Cnull%2C1%2C1%5D%2C%5B%5C%222024-02-02%5C%22%2C%5C%222024-05-02%5C%22%5D%5D%22%5D&";
         assert!(req.body.starts_with(expected));
         Ok(())
     }
@@ -205,7 +201,6 @@ mod tests {
             &StopoverDuration::UNLIMITED,
             &duration_max,
             true,
-            SortOrder::Best,
             None,
             None,
         );
@@ -216,7 +211,7 @@ mod tests {
             date_end_graph: "2024-05-02",
         };
 
-        let expected = r#"f.req=[null,"[null,[null,null,1,null,[],1,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"SYD\",0]]],null,0,null,null,\"2024-02-02\",null,null,null,null,null,null,null,3]],null,null,null,1,1],[\"2024-02-02\",\"2024-05-02\"]]"]"#;
+        let expected = r#"f.req=[null,"[null,[null,null,2,null,[],1,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"SYD\",0]]],null,0,null,null,\"2024-02-02\",null,null,null,null,null,null,null,3]],null,null,null,1,1],[\"2024-02-02\",\"2024-05-02\"]]"]"#;
         assert!(x.serialize_to_web()?.starts_with(expected));
         Ok(())
     }

--- a/src/parsers/request/date_grid_request.rs
+++ b/src/parsers/request/date_grid_request.rs
@@ -4,7 +4,7 @@ use chrono::NaiveDate;
 use percent_encoding::utf8_percent_encode;
 
 use crate::parsers::common::{
-    FlightTimes, Location, RequestBody, SerializeToWeb, SortOrder, StopOptions, StopoverDuration,
+    FlightTimes, Location, RequestBody, SerializeToWeb, StopOptions, StopoverDuration,
     ToRequestBody, TotalDuration, TravelClass, Travelers, CHARACTERS_TO_ENCODE,
 };
 use crate::parsers::constants::CALENDAR_GRID;
@@ -114,7 +114,6 @@ impl TryFrom<&DateGridRequestOptions<'_>> for RequestBody {
                 &StopoverDuration::UNLIMITED,
                 options.duration_max,
                 false,
-                SortOrder::Best,
                 None,
                 None,
             ),
@@ -152,12 +151,10 @@ impl SerializeToWeb for DateGridRequest<'_> {
     fn serialize_to_web(&self) -> Result<String> {
         let epoch_now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
 
-        // The date grid itinerary uses number=1 (not 2).  We achieve this by
-        // serialising the itinerary normally (which yields number=2 for a fresh
-        // request) and then replacing the leading `[null,null,2,` with
-        // `[null,null,1,`.  This is safe: the prefix is unique and always present.
-        let raw_itinerary = self.itinerary.serialize_to_web()?;
-        let itinerary = raw_itinerary.replacen("[null,null,2,", "[null,null,1,", 1);
+        // The grid is round-trip only, so the itinerary serialises with
+        // trip type 1 — round trip — at position 2, exactly what the
+        // endpoint expects.
+        let itinerary = self.itinerary.serialize_to_web()?;
 
         Ok(format!(
             r#"f.req=[null,"[null,{0},[\"{1}\",\"{2}\"],[\"{3}\",\"{4}\"]]"]&at=AAuQa1qiXfSThbBOCdcDUAVTopoc:{5}&"#,

--- a/src/parsers/request/flight_request.rs
+++ b/src/parsers/request/flight_request.rs
@@ -104,6 +104,7 @@ impl TryFrom<&FlightRequestOptions<'_>> for RequestBody {
             airlines_exclude: exc,
             connecting_airports: conn,
             lower_emissions: low_co2,
+            is_return: false,
         };
         let leg2 = options.date_return.map(|date_return| SingleLegStruct {
             departure: arrival,
@@ -119,6 +120,7 @@ impl TryFrom<&FlightRequestOptions<'_>> for RequestBody {
             airlines_exclude: exc,
             connecting_airports: conn,
             lower_emissions: low_co2,
+            is_return: true,
         });
         let legs: Vec<SingleLegStruct<'_>> = if let Some(leg_2) = leg2 {
             vec![leg1, leg_2]
@@ -185,6 +187,15 @@ pub struct SingleLegStruct<'a> {
     pub connecting_airports: &'a [String],
     /// Lower-emissions filter (position \[13\]): sends `[1]` when `true`.
     pub lower_emissions: bool,
+    /// `true` when this leg is the return leg of a round trip.
+    ///
+    /// Serialized as the display classifier at position \[14\]: `3` for the
+    /// outbound or only leg, `1` for the return leg. `GetShoppingResults`
+    /// tolerates a uniform `3`, but `GetBookingResults` rejects the request
+    /// with INVALID_ARGUMENT unless the return leg carries `1` — verified by
+    /// <https://github.com/punitarani/fli> against the browser's own POST
+    /// body in May 2026.
+    pub is_return: bool,
 }
 
 /// Serialise a slice of [`AirlineFilter`] values to the Google Flights wire
@@ -267,8 +278,8 @@ impl SerializeToWeb for SingleLegStruct<'_> {
         //   [11] min layover minutes or null
         //   [12] max layover minutes or null
         //   [13] lower-emissions flag [1] or null
-        //   [14] display classifier: 3 = outbound / one-way
-        let flight_to_show: i32 = 3;
+        //   [14] display classifier: 3 = outbound / one-way, 1 = return leg
+        let flight_to_show: i32 = if self.is_return { 1 } else { 3 };
 
         let chosen_itinerary = match self.chosen_itinerary {
             Some(x) => x.clone().serialize_to_web()?,
@@ -344,6 +355,7 @@ impl<'a> ItineraryRequest<'a> {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         legs.push(first);
         if let Some(x) = date_return {
@@ -361,6 +373,11 @@ impl<'a> ItineraryRequest<'a> {
                 airlines_exclude: &[],
                 connecting_airports: &[],
                 lower_emissions: false,
+                // Calendar-graph and date-grid requests keep the classifier
+                // at 3 for every segment, matching the date-search encoding in
+                // <https://github.com/punitarani/fli>. The 3-outbound/1-return
+                // pattern only applies to shopping and booking requests.
+                is_return: false,
             })
         };
         ItineraryRequest {
@@ -667,7 +684,7 @@ mod tests {
         };
 
         let req: RequestBody = (&search_settings).try_into()?;
-        let expected = "f.req=%5Bnull%2C%22%5B%5B%5D%2C%5Bnull%2Cnull%2C1%2Cnull%2C%5B%5D%2C1%2C%5B1%2C0%2C0%2C0%5D%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5B%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-02-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%2C%5B%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-03-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%5D%2Cnull%2Cnull%2Cnull%2C1%5D%2C0%2C0%2C0%2C1%5D%22%5D";
+        let expected = "f.req=%5Bnull%2C%22%5B%5B%5D%2C%5Bnull%2Cnull%2C1%2Cnull%2C%5B%5D%2C1%2C%5B1%2C0%2C0%2C0%5D%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5B%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-02-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%2C%5B%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-03-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C1%5D%5D%2Cnull%2Cnull%2Cnull%2C1%5D%2C1%2C0%2C0%5D%22%5D";
         assert!(req.body.starts_with(expected));
         Ok(())
     }
@@ -712,6 +729,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         assert_eq!(
             a.serialize_to_web()?,
@@ -749,6 +767,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         assert_eq!(
             a.serialize_to_web()?,
@@ -786,6 +805,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         assert_eq!(
             a.serialize_to_web()?,
@@ -823,6 +843,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         assert_eq!(
             a.serialize_to_web()?,
@@ -860,6 +881,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         let second = SingleLegStruct {
             departure: vec![vec![&arrival]],
@@ -875,6 +897,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         let travelers = Travelers::new([1, 0, 0, 0].to_vec())?;
 
@@ -983,6 +1006,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         assert_eq!(
             a.serialize_to_web()?,
@@ -1021,6 +1045,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         assert_eq!(
             a.serialize_to_web()?,
@@ -1059,6 +1084,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         assert_eq!(
             a.serialize_to_web()?,
@@ -1105,6 +1131,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         let expected = format!(
             r#"[[[[\"LHR\",0],[\"LGW\",0]]],[[[\"JFK\",0]]],null,0,null,null,\"{date}\",null,null,null,null,null,null,null,3]"#
@@ -1319,6 +1346,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &[],
             lower_emissions: false,
+            is_return: false,
         };
         let without = leg_no_emissions.serialize_to_web().unwrap();
         assert!(without.ends_with(",null,3]"), "no emissions: {without}");
@@ -1362,6 +1390,7 @@ mod tests {
             airlines_exclude: &[],
             connecting_airports: &via,
             lower_emissions: false,
+            is_return: false,
         };
         // Capture leg (CDG→SIN, via DXB):
         //   [[[["CDG",0]]],[[["SIN",0]]],null,*,null,null,"2026-07-03",
@@ -1380,5 +1409,39 @@ mod tests {
         assert_eq!(serialize_baggage(Some((1, 2))), "[2,1]");
         assert_eq!(serialize_baggage(Some((0, 1))), "[1,0]");
         assert_eq!(serialize_baggage(None), "null");
+    }
+    #[test]
+    fn test_return_leg_classifier_is_one() -> Result<()> {
+        let departure = Location {
+            loc_identifier: "MXP".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: None,
+        };
+        let arrival = Location {
+            loc_identifier: "CDG".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: None,
+        };
+        let binding = FlightTimes::default();
+        let stopover_max = StopoverDuration::UNLIMITED;
+        let duration_max = TotalDuration::UNLIMITED;
+        let leg = SingleLegStruct {
+            departure: vec![vec![&arrival]],
+            arrival: vec![vec![&departure]],
+            stop_options: &StopOptions::All,
+            date: "2022-10-30",
+            times: &binding,
+            stopover_max: &stopover_max,
+            stopover_min: &StopoverDuration::UNLIMITED,
+            duration_max: &duration_max,
+            chosen_itinerary: None,
+            airlines_include: &[],
+            airlines_exclude: &[],
+            connecting_airports: &[],
+            lower_emissions: false,
+            is_return: true,
+        };
+        assert!(leg.serialize_to_web()?.ends_with(",1]"));
+        Ok(())
     }
 }

--- a/src/parsers/request/flight_request.rs
+++ b/src/parsers/request/flight_request.rs
@@ -232,10 +232,14 @@ fn serialize_price_filter(max: Option<i32>) -> String {
 
 /// Serialise the baggage filter to the Google Flights wire format.
 ///
-/// `[carry_on_count, checked_count]` when set; `null` when absent.
+/// `[checked_count, carry_on_count]` when set; `null` when absent.
+/// The wire order is checked-first — verified against the web UI's own
+/// request body and the independently reverse-engineered index map in
+/// <https://github.com/punitarani/fli>, which documents main settings
+/// position 10 as `[checked_bags, carry_on]`.
 fn serialize_baggage(b: Option<(u8, u8)>) -> String {
     match b {
-        Some((carry_on, checked)) => format!("[{carry_on},{checked}]"),
+        Some((carry_on, checked)) => format!("[{checked},{carry_on}]"),
         None => "null".to_owned(),
     }
 }
@@ -1368,5 +1372,13 @@ mod tests {
             s.contains(r#"\"2026-07-03\",null,null,[\"DXB\"],null,"#),
             "via [9] must encode as [\"DXB\"] like the web UI: {s}"
         );
+    }
+    #[test]
+    fn test_serialize_baggage_wire_order_is_checked_first() {
+        // Config carries carry-on first, checked second; the wire wants
+        // checked first.
+        assert_eq!(serialize_baggage(Some((1, 2))), "[2,1]");
+        assert_eq!(serialize_baggage(Some((0, 1))), "[1,0]");
+        assert_eq!(serialize_baggage(None), "null");
     }
 }

--- a/src/parsers/request/flight_request.rs
+++ b/src/parsers/request/flight_request.rs
@@ -13,6 +13,7 @@ use crate::parsers::common::{
 use crate::parsers::constants::{BOOKING_REQUEST, FLIGHT_REQUEST};
 use crate::parsers::response::flight_response::FlightInfo;
 use crate::requests::config::multi_city::{leg_tail, MultiCityConfig};
+use crate::requests::config::TripType;
 use anyhow::Result;
 
 pub struct FlightRequestOptions<'a> {
@@ -128,12 +129,19 @@ impl TryFrom<&FlightRequestOptions<'_>> for RequestBody {
             vec![leg1]
         };
 
+        let is_booking = options.fixed_flights.is_full();
+
+        let trip_type = if options.date_return.is_some() {
+            TripType::Return
+        } else {
+            TripType::OneWay
+        };
         let itinerary = ItineraryRequest {
             legs,
             travel_class: options.travel_class,
             travelers: &options.travellers,
             is_graph: false,
-            sort_order: *options.sort_order,
+            trip_type,
             max_price: options.max_price,
             baggage: options.baggage,
         };
@@ -145,6 +153,7 @@ impl TryFrom<&FlightRequestOptions<'_>> for RequestBody {
             itinerary,
             departure_token: departure_token.as_deref(),
             is_booking,
+            sort_order: *options.sort_order,
         };
         let body = complete_flight_request.serialize_to_web()?;
         let endpoint = if is_booking {
@@ -312,8 +321,12 @@ pub struct ItineraryRequest<'a> {
     pub travel_class: &'a TravelClass,
     pub travelers: &'a Travelers,
     pub is_graph: bool,
-    /// Sort order sent to Google Flights (position 2 in the outer request array).
-    pub sort_order: SortOrder,
+    /// Trip type at position 2 of the itinerary array: 1 round trip,
+    /// 2 one-way, 3 multi-city. This slot previously carried the sort
+    /// order, which the server interprets as a trip type — the real sort
+    /// slot is position 2 of the *outer* request array; see
+    /// `CompleteFlightRequest`.
+    pub trip_type: TripType,
     /// Maximum price filter (position 7 of the outer itinerary array). `None` = no price cap.
     pub max_price: Option<i32>,
     /// Baggage filter (position 10 of the outer itinerary array). `None` = no restriction.
@@ -336,7 +349,6 @@ impl<'a> ItineraryRequest<'a> {
         stopover_min: &'a StopoverDuration,
         duration_max: &'a TotalDuration,
         is_graph: bool,
-        sort_order: SortOrder,
         max_price: Option<i32>,
         baggage: Option<(u8, u8)>,
     ) -> Self {
@@ -380,12 +392,17 @@ impl<'a> ItineraryRequest<'a> {
                 is_return: false,
             })
         };
+        let trip_type = if date_return.is_some() {
+            TripType::Return
+        } else {
+            TripType::OneWay
+        };
         ItineraryRequest {
             legs,
             travel_class,
             travelers,
             is_graph,
-            sort_order,
+            trip_type,
             max_price,
             baggage,
         }
@@ -396,18 +413,19 @@ impl SerializeToWeb for ItineraryRequest<'_> {
     fn serialize_to_web(&self) -> Result<String> {
         let graph = if self.is_graph { ",1" } else { "" };
         Ok(format!(
-            // [null,null,{sort},null,[],{class},{travelers},{price},null,null,{baggage},null,null,{legs},null,null,null,1{graph}]
+            // [null,null,{trip},null,[],{class},{travelers},{price},null,null,{baggage},null,null,{legs},null,null,null,1{graph}]
             //   [0]  null
-            //   [2]  sort order
+            //   [2]  trip type: 1 round trip, 2 one-way, 3 multi-city
             //   [5]  travel class
             //   [6]  travelers
             //   [7]  max price filter
             //   [10] baggage filter
             //   [13] legs
+            //   [17] constant 1
             r#"[null,null,{0},null,[],{1},{2},{3},null,null,{4},null,null,{5},null,null,null,1{6}]"#,
-            self.sort_order as i32,
-            self.travel_class.serialize_to_web()?,
-            self.travelers.serialize_to_web()?,
+            self.trip_type as i32,
+            &self.travel_class.serialize_to_web()?,
+            &self.travelers.serialize_to_web()?,
             serialize_price_filter(self.max_price),
             serialize_baggage(self.baggage),
             self.legs.serialize_to_web()?,
@@ -422,6 +440,9 @@ struct CompleteFlightRequest<'a> {
     /// `true` when all flight legs are fixed — triggers the `GetBookingResults`
     /// endpoint and the matching `null,0` body tail the browser uses.
     is_booking: bool,
+    /// Result sort order, sent at position 2 of the outer request array.
+    /// Shopping requests only — booking requests have no sort slot.
+    sort_order: SortOrder,
 }
 
 impl SerializeToWeb for CompleteFlightRequest<'_> {
@@ -433,13 +454,17 @@ impl SerializeToWeb for CompleteFlightRequest<'_> {
             None => "[]".to_string(),
         };
 
-        // Body tail, matching the live browser wire format exactly:
-        //   * GetBookingResults  -> `null,0`
-        //   * GetShoppingResults -> `0,0,0,1` (both the plain search and the
-        //     token-bearing "outbound selected" step use this)
-        // The previous `1,0,0` is rejected by the backend with an
-        // `ErrorResponse`, so search/offer must send `0,0,0,1`.
-        let end_part = if self.is_booking { "null,0" } else { "0,0,0,1" };
+        // Booking requests (GetBookingResults) use `null,0` as the body tail —
+        // matching what the browser sends.  Shopping requests carry
+        // `{sort},{show_all},0,1`: the sort mode at outer position 2 and the
+        // show-all-results flag at position 3, where 1 requests the full list
+        // and 0 caps results at roughly 30 curated rows — matching the web
+        // UI's own request body.
+        let end_part = if self.is_booking {
+            "null,0".to_owned()
+        } else {
+            format!("{},1,0,1", self.sort_order.server_sort() as i32)
+        };
 
         Ok(format!(
             r#"f.req=[null,"[{},{},{}]"]&at=AAuQa1qiXfSThbBOCdcDUAVTopoc:{}&"#,
@@ -632,8 +657,14 @@ mod tests {
         };
 
         let req: RequestBody = (&search_settings).try_into()?;
-        let expected = "f.req=%5Bnull%2C%22%5B%5B%5D%2C%5Bnull%2Cnull%2C1%2Cnull%2C%5B%5D%2C1%2C%5B1%2C0%2C0%2C0%5D%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5B%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-02-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%5D%2Cnull%2Cnull%2Cnull%2C1%5D%2C0%2C0%2C0%2C1%5D%22%5D&";
-        assert!(req.body.starts_with(expected));
+        // Decode for a readable assertion: trip type 2 for one-way at
+        // itinerary position [2]; outer tail = sort 1 for Best, show-all 1,
+        // then 0, 1.
+        let decoded = percent_encoding::percent_decode_str(&req.body)
+            .decode_utf8()?
+            .to_string();
+        let expected = r#"f.req=[null,"[[],[null,null,2,null,[],1,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"SYD\",0]]],null,0,null,null,\"2024-02-02\",null,null,null,null,null,null,null,3]],null,null,null,1],1,1,0,1]"]&"#;
+        assert!(decoded.starts_with(expected), "decoded body was: {decoded}");
 
         assert!(req.url.contains(&frontend_version));
         Ok(())
@@ -684,8 +715,13 @@ mod tests {
         };
 
         let req: RequestBody = (&search_settings).try_into()?;
-        let expected = "f.req=%5Bnull%2C%22%5B%5B%5D%2C%5Bnull%2Cnull%2C1%2Cnull%2C%5B%5D%2C1%2C%5B1%2C0%2C0%2C0%5D%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5B%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-02-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C3%5D%2C%5B%5B%5B%5B%5C%22SYD%5C%22%2C0%5D%5D%5D%2C%5B%5B%5B%5C%22MXP%5C%22%2C0%5D%5D%5D%2Cnull%2C0%2Cnull%2Cnull%2C%5C%222024-03-02%5C%22%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C1%5D%5D%2Cnull%2Cnull%2Cnull%2C1%5D%2C1%2C0%2C0%5D%22%5D";
-        assert!(req.body.starts_with(expected));
+        // Trip type 1 for round trip; outbound leg classifier 3, return leg
+        // 1; outer tail = sort 1 for Best, show-all 1, then 0, 1.
+        let decoded = percent_encoding::percent_decode_str(&req.body)
+            .decode_utf8()?
+            .to_string();
+        let expected = r#"f.req=[null,"[[],[null,null,1,null,[],1,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"SYD\",0]]],null,0,null,null,\"2024-02-02\",null,null,null,null,null,null,null,3],[[[[\"SYD\",0]]],[[[\"MXP\",0]]],null,0,null,null,\"2024-03-02\",null,null,null,null,null,null,null,1]],null,null,null,1],1,1,0,1]"]&"#;
+        assert!(decoded.starts_with(expected), "decoded body was: {decoded}");
         Ok(())
     }
 
@@ -906,12 +942,12 @@ mod tests {
             travel_class: &TravelClass::Economy,
             travelers: &travelers,
             is_graph: false,
-            sort_order: SortOrder::Best,
+            trip_type: TripType::OneWay,
             max_price: None,
             baggage: None,
         };
 
-        let expected_single_leg = r#"[null,null,1,null,[],1,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"CDG\",0]]],null,0,null,null,\"2022-10-20\",null,null,null,null,null,null,null,3]],null,null,null,1]"#;
+        let expected_single_leg = r#"[null,null,2,null,[],1,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"CDG\",0]]],null,0,null,null,\"2022-10-20\",null,null,null,null,null,null,null,3]],null,null,null,1]"#;
         assert_eq!(itinerary.serialize_to_web()?, expected_single_leg);
         let expected_two_legs = r#"[null,null,1,null,[],1,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"CDG\",0]]],null,0,null,null,\"2022-10-20\",null,null,null,null,null,null,null,3],[[[[\"CDG\",0]]],[[[\"MXP\",0]]],null,0,null,null,\"2022-10-30\",null,null,null,null,null,null,null,3]],null,null,null,1]"#;
         let itinerary_return = ItineraryRequest {
@@ -919,7 +955,7 @@ mod tests {
             travel_class: &TravelClass::Economy,
             travelers: &travelers,
             is_graph: false,
-            sort_order: SortOrder::Best,
+            trip_type: TripType::Return,
             max_price: None,
             baggage: None,
         };
@@ -931,7 +967,7 @@ mod tests {
     fn test_complete_flight_request() -> Result<()> {
         let travelers = Travelers::new([1, 0, 0, 0].to_vec())?;
 
-        let expected_two_legs = r#"f.req=[null,"[[],[null,null,1,null,[],4,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"CDG\",0]]],null,0,null,null,\"2022-10-20\",null,null,null,null,null,null,null,3],[[[[\"CDG\",0]]],[[[\"MXP\",0]]],null,0,null,null,\"2022-10-30\",null,null,null,null,null,null,null,3]],null,null,null,1],0,0,0,1]"]&at=AAuQa1qiXfSThbBOCdcDUAVTopoc:"#;
+        let expected_two_legs = r#"f.req=[null,"[[],[null,null,1,null,[],4,[1,0,0,0],null,null,null,null,null,null,[[[[[\"MXP\",0]]],[[[\"CDG\",0]]],null,0,null,null,\"2022-10-20\",null,null,null,null,null,null,null,3],[[[[\"CDG\",0]]],[[[\"MXP\",0]]],null,0,null,null,\"2022-10-30\",null,null,null,null,null,null,null,3]],null,null,null,1],1,1,0,1]"]&at=AAuQa1qiXfSThbBOCdcDUAVTopoc:"#;
 
         let departure = Location {
             loc_identifier: "MXP".to_owned(),
@@ -960,7 +996,6 @@ mod tests {
             &StopoverDuration::UNLIMITED,
             &duration_max,
             false,
-            SortOrder::Best,
             None,
             None,
         );
@@ -969,6 +1004,7 @@ mod tests {
             itinerary: itinerary_return,
             departure_token: None,
             is_booking: false,
+            sort_order: SortOrder::Best,
         };
         assert!(complete_req
             .serialize_to_web()?
@@ -1442,6 +1478,50 @@ mod tests {
             is_return: true,
         };
         assert!(leg.serialize_to_web()?.ends_with(",1]"));
+        Ok(())
+    }
+    #[test]
+    fn test_sort_order_lands_in_outer_array() -> Result<()> {
+        let departure = Location {
+            loc_identifier: "MXP".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: None,
+        };
+        let arrival = Location {
+            loc_identifier: "CDG".to_owned(),
+            loc_type: PlaceType::Airport,
+            location_name: None,
+        };
+        let stopover_max = StopoverDuration::UNLIMITED;
+        let duration_max = TotalDuration::UNLIMITED;
+        let binding = FlightTimes::default();
+        let travelers = Travelers::new([1, 0, 0, 0].to_vec())?;
+        let itinerary = ItineraryRequest::new(
+            core::slice::from_ref(&departure),
+            core::slice::from_ref(&arrival),
+            &StopOptions::All,
+            "2022-10-20",
+            &None,
+            &travelers,
+            &TravelClass::Economy,
+            &binding,
+            &binding,
+            &stopover_max,
+            &StopoverDuration::UNLIMITED,
+            &duration_max,
+            false,
+            None,
+            None,
+        );
+        let complete = CompleteFlightRequest {
+            itinerary,
+            departure_token: None,
+            is_booking: false,
+            sort_order: SortOrder::Price,
+        };
+        let body = complete.serialize_to_web()?;
+        // Sort mode 2 — price — at outer position 2, show-all = 1.
+        assert!(body.contains(r#",2,1,0,1]"]&at="#), "body: {body}");
         Ok(())
     }
 }

--- a/src/parsers/request/flight_request.rs
+++ b/src/parsers/request/flight_request.rs
@@ -508,9 +508,11 @@ impl TryFrom<&MultiCityRequestOptions<'_>> for RequestBody {
 
         let legs_json = build_multi_city_legs(cfg)?;
 
+        // Itinerary position [2] is the trip type — 3 for multi-city; the
+        // sort mode goes at position 2 of the *outer* array below.
         let itinerary_json = format!(
-            r#"[null,null,{sort},null,[],{class},{travelers},{price},null,null,{baggage},null,null,{legs},null,null,null,1]"#,
-            sort = server_sort as i32,
+            r#"[null,null,{trip},null,[],{class},{travelers},{price},null,null,{baggage},null,null,{legs},null,null,null,1]"#,
+            trip = TripType::MultiCity as i32,
             class = cfg.travel_class.serialize_to_web()?,
             travelers = cfg.travellers.serialize_to_web()?,
             price = serialize_price_filter(cfg.max_price),
@@ -523,8 +525,9 @@ impl TryFrom<&MultiCityRequestOptions<'_>> for RequestBody {
             .as_millis();
 
         let body = format!(
-            r#"f.req=[null,"[[],{itinerary},0,0,0,1]"]&at=AAuQa1qiXfSThbBOCdcDUAVTopoc:{epoch}&"#,
+            r#"f.req=[null,"[[],{itinerary},{sort},1,0,1]"]&at=AAuQa1qiXfSThbBOCdcDUAVTopoc:{epoch}&"#,
             itinerary = itinerary_json,
+            sort = server_sort as i32,
             epoch = epoch_now,
         );
 

--- a/src/requests/api.rs
+++ b/src/requests/api.rs
@@ -354,7 +354,6 @@ impl ApiClient {
             frontend_version: &self.frontend_version,
             language: &self.language,
             country: &self.country,
-            sort_order: &args.sort_order,
         };
         let body = self
             .do_request(
@@ -601,8 +600,6 @@ impl ApiClient {
     async fn fetch_flight_body(&self, args: &Config) -> Result<String> {
         let date_start = args.departing_date.to_string();
         let date_return = args.return_date.map(|f| f.to_string());
-        // DepartureTime/ArrivalTime are client-side-only sorts; the backend does
-        // not accept those discriminants and returns an empty result if sent.
         let server_sort = args.sort_order.server_sort();
         let req_options = FlightRequestOptions {
             departing_city: &args.departure,

--- a/src/requests/config/mod.rs
+++ b/src/requests/config/mod.rs
@@ -24,12 +24,15 @@ pub use explore::{
 pub use multi_city::{LegFilters, MultiCityConfig, MultiCityConfigBuilder, MultiCityLeg};
 
 /// The `TripType` enum is used to specify the type of trip.
+///
+/// Discriminants are the wire values Google Flights expects at position
+/// \[2\] of the itinerary array: 1 round trip, 2 one-way, 3 multi-city.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum TripType {
+    Return = 1,
     #[default]
-    OneWay,
-    Return,
-    MultiCity,
+    OneWay = 2,
+    MultiCity = 3,
 }
 
 /// The `Config` struct is used to specify the options for a flight search.

--- a/src/requests/config/multi_city.rs
+++ b/src/requests/config/multi_city.rs
@@ -498,4 +498,43 @@ mod tests {
              decoded first-leg section: {first_leg_section}"
         );
     }
+
+    /// Multi-city requests must carry trip type 3 at itinerary position [2]
+    /// and the sort mode at position 2 of the outer request array.
+    #[test]
+    fn multi_city_sends_trip_type_3_and_sort_in_outer_array() {
+        use crate::parsers::common::ToRequestBody;
+        use crate::parsers::request::flight_request::MultiCityRequestOptions;
+
+        let cfg = MultiCityConfig {
+            legs: vec![
+                leg("LUX", "FCO", "2026-09-10"),
+                leg("FCO", "MAD", "2026-09-13"),
+            ],
+            travellers: Travelers::new(vec![1, 0, 0, 0]).unwrap(),
+            travel_class: TravelClass::Economy,
+            sort_order: SortOrder::Price,
+            max_price: None,
+            baggage: None,
+        };
+        let opts = MultiCityRequestOptions {
+            config: &cfg,
+            frontend_version: "test-version",
+            language: "en",
+            country: "GB",
+        };
+        let body = opts.to_request_body().unwrap();
+        let decoded = percent_encoding::percent_decode_str(&body.body)
+            .decode_utf8_lossy()
+            .to_string();
+
+        assert!(
+            decoded.contains(r#"[[],[null,null,3,null,[]"#),
+            "trip type 3 expected at itinerary position [2]; decoded: {decoded}"
+        );
+        assert!(
+            decoded.contains(r#",2,1,0,1]"]&at="#),
+            "sort mode 2 — price — expected in the outer tail; decoded: {decoded}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- serialize baggage as checked bags before carry-on bags
- use the required return-leg display classifier for booking offers
- write trip type and sort order to their actual wire slots and request the full result list
- send multi-city trip type 3 with sorting in the outer request array

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --all-targets`
- `cargo test --lib` — 215 passed
- `cargo test --bin gflights` — 37 passed
- `cargo test --doc` — 11 passed, 1 ignored
- `git diff --check upstream/master..HEAD`